### PR TITLE
Add Buglife

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -152,6 +152,9 @@ dependencies {
     // FlexboxLayout
     implementation "com.google.android:flexbox:$flexbox"
 
+    // Buglife
+    implementation "com.buglife.sdk:buglife-android:$buglife"
+
     implementation project(':android:repository')
 }
 

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/App.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/App.kt
@@ -35,6 +35,8 @@ class App : DaggerApplication() {
         Buglife.setInvocationMethod(InvocationMethod.SHAKE)
 
         val summaryField = TextInputField.summaryInputField()
+        val emailField = TextInputField(getString(R.string.buglife_email))
+        emailField.setMultiline(false)
         val reproducibilityField = PickerInputField(getString(R.string.buglife_reproducibility))
         resources.getStringArray(R.array.buglife_reproducibility_levels).forEach {
             reproducibilityField.addOption(it)
@@ -42,7 +44,7 @@ class App : DaggerApplication() {
         val stepsField = TextInputField(getString(R.string.buglife_steps_to_reproduce))
         stepsField.setMultiline(true)
 
-        Buglife.setInputFields(summaryField, reproducibilityField, stepsField)
+        Buglife.setInputFields(summaryField, emailField, reproducibilityField, stepsField)
     }
 
     override fun applicationInjector(): AndroidInjector<out DaggerApplication> {

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/App.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/App.kt
@@ -1,7 +1,12 @@
 package ca.etsmtl.applets.etsmobile.presentation
 
+import ca.etsmtl.applets.etsmobile.R
 import ca.etsmtl.applets.etsmobile.di.DaggerAppComponent
 import ca.etsmtl.applets.repository.di.RepositoryModule
+import com.buglife.sdk.Buglife
+import com.buglife.sdk.InvocationMethod
+import com.buglife.sdk.PickerInputField
+import com.buglife.sdk.TextInputField
 import com.squareup.leakcanary.LeakCanary
 import dagger.android.AndroidInjector
 import dagger.android.support.DaggerApplication
@@ -20,6 +25,24 @@ class App : DaggerApplication() {
             return
         }
         LeakCanary.install(this)
+
+        setupBuglife()
+    }
+
+    private fun setupBuglife() {
+        Buglife.initWithApiKey(this, "TODO") // TODO: Insert Buglife key here
+        Buglife.setInvocationMethod(InvocationMethod.BUG_BUTTON)
+        Buglife.setInvocationMethod(InvocationMethod.SHAKE)
+
+        val summaryField = TextInputField.summaryInputField()
+        val reproducibilityField = PickerInputField(getString(R.string.buglife_reproducibility))
+        resources.getStringArray(R.array.buglife_reproducibility_levels).forEach {
+            reproducibilityField.addOption(it)
+        }
+        val stepsField = TextInputField(getString(R.string.buglife_steps_to_reproduce))
+        stepsField.setMultiline(true)
+
+        Buglife.setInputFields(summaryField, reproducibilityField, stepsField)
     }
 
     override fun applicationInjector(): AndroidInjector<out DaggerApplication> {

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/more/MoreFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/more/MoreFragment.kt
@@ -73,7 +73,7 @@ class MoreFragment : DaggerFragment() {
     }
 
     private fun subscribeUI() {
-        moreViewModel.displayLogoutDialog.observe(this, Observer {
+        moreViewModel.displayLogoutConfirmationDialog.observe(this, Observer {
             logoutConfirmationDialog.takeIf { it != null && !it.isShowing }?.let { dialog ->
                 if (it == true) {
                     dialog.show()

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/more/MoreViewModel.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/more/MoreViewModel.kt
@@ -12,6 +12,7 @@ import ca.etsmtl.applets.etsmobile.presentation.App
 import ca.etsmtl.applets.etsmobile.presentation.about.AboutActivity
 import ca.etsmtl.applets.etsmobile.presentation.login.WelcomeActivity
 import ca.etsmtl.applets.etsmobile.util.Event
+import com.buglife.sdk.Buglife
 import javax.inject.Inject
 
 /**
@@ -27,13 +28,13 @@ class MoreViewModel @Inject constructor(
         ABOUT, LOGOUT
     }
 
-    private val _displayLogoutConfirmationDialog by lazy { MutableLiveData<Boolean>() }
-    private val _displayMessage by lazy { MutableLiveData<Event<String>>() }
     private val logoutMediatorLiveData by lazy { MediatorLiveData<Boolean>() }
-    private val _activityToGoTo by lazy { MutableLiveData<Event<Class<out Activity>>>() }
     val loading: LiveData<Boolean> = Transformations.map(logoutMediatorLiveData) { it }
-    val displayLogoutDialog: LiveData<Boolean> = _displayLogoutConfirmationDialog
+    private val _displayLogoutConfirmationDialog by lazy { MutableLiveData<Boolean>() }
+    val displayLogoutConfirmationDialog: LiveData<Boolean> = _displayLogoutConfirmationDialog
+    private val _displayMessage by lazy { MutableLiveData<Event<String>>() }
     val displayMessage: LiveData<Event<String>> = _displayMessage
+    private val _activityToGoTo by lazy { MutableLiveData<Event<Class<out Activity>>>() }
     val activityToGoTo: LiveData<Event<Class<out Activity>>> = _activityToGoTo
 
     /**
@@ -64,10 +65,20 @@ class MoreViewModel @Inject constructor(
             MoreItem(R.drawable.ic_mini_logo_applets, R.string.more_item_label_about_applets) {
                 _activityToGoTo.value = Event(AboutActivity::class.java)
             },
+            MoreItem(R.drawable.ic_bug_report_black_24dp, R.string.more_item_report_bug) {
+                navigateToBuglifeReporter()
+            },
             MoreItem(R.drawable.ic_exit_to_app_black_24dp, R.string.more_item_label_log_out) {
                 _displayLogoutConfirmationDialog.value = true
             }
         )
+    }
+
+    private fun navigateToBuglifeReporter() {
+        val screenShot = Buglife.captureScreenshot() // TODO: Let user attach his own file
+
+        screenShot?.let { Buglife.addAttachment(it) }
+        Buglife.showReporter()
     }
 
     fun clickLogoutConfirmationDialogButton(confirmedLogout: Boolean) {

--- a/android/app/src/main/res/drawable/ic_bug_report_black_24dp.xml
+++ b/android/app/src/main/res/drawable/ic_bug_report_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M20,8h-2.81c-0.45,-0.78 -1.07,-1.45 -1.82,-1.96L17,4.41 15.59,3l-2.17,2.17C12.96,5.06 12.49,5 12,5c-0.49,0 -0.96,0.06 -1.41,0.17L8.41,3 7,4.41l1.62,1.63C7.88,6.55 7.26,7.22 6.81,8L4,8v2h2.09c-0.05,0.33 -0.09,0.66 -0.09,1v1L4,12v2h2v1c0,0.34 0.04,0.67 0.09,1L4,16v2h2.81c1.04,1.79 2.97,3 5.19,3s4.15,-1.21 5.19,-3L20,18v-2h-2.09c0.05,-0.33 0.09,-0.66 0.09,-1v-1h2v-2h-2v-1c0,-0.34 -0.04,-0.67 -0.09,-1L20,10L20,8zM14,16h-4v-2h4v2zM14,12h-4v-2h4v2z"/>
+</vector>

--- a/android/app/src/main/res/values-en/strings.xml
+++ b/android/app/src/main/res/values-en/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="error">An error has occurred</string>
     <string name="error_no_internet_connection">No internet connection</string>
     <string name="yes">Yes</string>
@@ -87,4 +87,30 @@
     <string name="applets_about">ÉTSMobile was conceived by the ApplETS scientific club from the École de technologie supérieure.\n\nApplets is, most importantly, a gathering of students who share a typical enthusiasm for the field of telecommunications and mobile applications.
         The mission of ApplETS is to train students in mobile development and promote the production of mobile applications within the student community.\n\nFor more information, please consult our website : http://clubapplets.ca</string>
     <string name="msg_no_seances">No class period for this semester</string>
+
+    <!-- Buglife -->
+    <string name="screenshot_annotator_activity_label" tools:override="true">Screenshot</string>
+    <string name="what_happened_edit_text" tools:override="true">What happened?</string>
+    <string name="sending_toast" tools:override="true">Submitting bug report…</string>
+    <string name="thanks_for_filing_a_bug" tools:override="true">Thanks for filing a bug!</string>
+    <string name="error_unable_to_read_screenshot" tools:override="true">Oops! Buglife was unable to capture your screenshot.</string>
+    <string name="help_us_make_this_app_better" tools:override="true">Help us make this app better!</string>
+    <string name="report_a_bug" tools:override="true">Report a Bug</string>
+    <string name="cancel" tools:override="true">Cancel</string>
+    <string name="next" tools:override="true">Next</string>
+    <string name="send" tools:override="true">Send</string>
+    <string name="error_dialog_title" tools:override="true">Oops!</string>
+    <string name="error_dialog_message" tools:override="true">Something went wrong submitting your bug report. Please try again.</string>
+    <string name="error_dialog_message_check_logs" tools:override="true">Something went wrong submitting your bug report. If you are a developer, please check the application logs.</string>
+    <string name="error_serialize_report" tools:override="true">Failed to serialize bug report!</string>
+    <string name="error_process_report" tools:override="true">There was an error processing bug report!</string>
+    <string name="error_save_screenshot" tools:override="true">There was an error saving screenshot!</string>
+    <string name="buglife_email">Email Address</string>
+    <string name="buglife_reproducibility">Reproducibility</string>
+    <string-array name="buglife_reproducibility_levels">
+        <item>Always</item>
+        <item>Sometimes</item>
+        <item>Rarely</item>
+    </string-array>
+    <string name="buglife_steps_to_reproduce">Steps to reproduce</string>
 </resources>

--- a/android/app/src/main/res/values-en/strings.xml
+++ b/android/app/src/main/res/values-en/strings.xml
@@ -79,6 +79,7 @@
     <!-- More -->
     <string name="more_item_label_faq">FAQ</string>
     <string name="more_item_label_about_applets">About ApplETS</string>
+    <string name="more_item_report_bug">Report a bug</string>
     <string name="more_item_label_log_out">Log out</string>
     <string name="prompt_log_out_confirmation">Are you sure you want to log out?</string>
     <string name="more_label_log_out_progress">Disconnection in progress</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -83,6 +83,7 @@
     <!-- More -->
     <string name="more_item_label_faq">FAQ</string>
     <string name="more_item_label_about_applets">À propos d\'ApplETS</string>
+    <string name="more_item_report_bug">Rapporter un bogue</string>
     <string name="more_item_label_log_out">Se déconnecter</string>
     <string name="prompt_log_out_confirmation">Êtes-vous certain de vouloir vous déconnecter?</string>
     <string name="more_label_log_out_progress">Déconnexion en cours</string>
@@ -100,7 +101,7 @@
     <string name="screenshot_annotator_activity_label" tools:override="true">Capture d\'écran</string>
     <string name="what_happened_edit_text" tools:override="true">Que s\'est-il passé?</string>
     <string name="sending_toast" tools:override="true">Soumission du rapport de bogue…</string>
-    <string name="thanks_for_filing_a_bug" tools:override="true">Thanks for filing a bug!Merci d\'avoir rapporté un bogue</string>
+    <string name="thanks_for_filing_a_bug" tools:override="true">Merci d\'avoir rapporté un bogue</string>
     <string name="error_unable_to_read_screenshot" tools:override="true">Oups! La capture d\'écran n\'a put être effectuée.</string>
     <string name="help_us_make_this_app_better" tools:override="true">Aidez-nous à améliorer cette application!</string>
     <string name="report_a_bug" tools:override="true">Rapporter un bogue</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="preference_file_key" translatable="false">ETSMobilePrefs</string>
     <string name="bottom_view_behavior" translatable="false">ca.etsmtl.applets.etsmobile.util.BottomNavigationBehavior</string>
     <string name="error">Une erreur est survenue</string>
@@ -95,4 +95,30 @@
     <string name="uri_applets_twitter" translatable="false">https://twitter.com/ClubApplETS</string>
     <string name="uri_applets_yt" translatable="false">https://www.youtube.com/channel/UCiSzzfW1bVbE_0KcEZO52ew</string>
     <string name="msg_no_seances">Aucune séance de cours pour la session actuelle</string>
+
+    <!-- Buglife -->
+    <string name="screenshot_annotator_activity_label" tools:override="true">Capture d\'écran</string>
+    <string name="what_happened_edit_text" tools:override="true">Que s\'est-il passé?</string>
+    <string name="sending_toast" tools:override="true">Soumission du rapport de bogue…</string>
+    <string name="thanks_for_filing_a_bug" tools:override="true">Thanks for filing a bug!Merci d\'avoir rapporté un bogue</string>
+    <string name="error_unable_to_read_screenshot" tools:override="true">Oups! La capture d\'écran n\'a put être effectuée.</string>
+    <string name="help_us_make_this_app_better" tools:override="true">Aidez-nous à améliorer cette application!</string>
+    <string name="report_a_bug" tools:override="true">Rapporter un bogue</string>
+    <string name="cancel" tools:override="true">Annuler</string>
+    <string name="next" tools:override="true">Suivant</string>
+    <string name="send" tools:override="true">Envoyer</string>
+    <string name="error_dialog_title" tools:override="true">Oops!</string>
+    <string name="error_dialog_message" tools:override="true">Une erreur est survenue pendant la soumission de votre rapport de bogue. Veuillez réessayer.</string>
+    <string name="error_dialog_message_check_logs" tools:override="true">Une erreur est survenue pendant la soumission de votre rapport de bogue. Si vous êtes un développeur, veuillez consulter les logs.</string>
+    <string name="error_serialize_report" tools:override="true">Échec de la sérialisation du rapport de bogue.</string>
+    <string name="error_process_report" tools:override="true">Une erreur est survenue lors du traitement du rapport de bogue!</string>
+    <string name="error_save_screenshot" tools:override="true">Une erreur est survenue lors de la sauvegarde du capture d\'écran.</string>
+    <string name="buglife_email">Adresse courriel</string>
+    <string name="buglife_reproducibility">Reproductibilité</string>
+    <string-array name="buglife_reproducibility_levels">
+        <item>Toujours</item>
+        <item>Parfois</item>
+        <item>Rarement</item>
+    </string-array>
+    <string name="buglife_steps_to_reproduce">Étapes pour reproduire</string>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
@@ -86,5 +86,12 @@
         <item name="android:textColorLink">@android:color/white</item>
         <item name="colorButtonNormal">@android:color/white</item>
         <item name="android:navigationBarColor">?android:attr/colorPrimary</item>
+    </style>
+
+    <!-- Buglife -->
+    <style name="buglife_alert_dialog" parent="Theme.MaterialComponents.Light.Dialog" tools:override="true">
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:textColor">@color/colorPrimary</item>
+        <item name="colorAccent">@color/colorPrimary</item>
     </style>
 </resources>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     // Versions
     ext.astl = '1.0.1'
+    ext.buglife = '1.3.3'
     ext.chuck = '1.1.0'
     ext.constraint_layout = '2.0.0-alpha2'
     ext.dagger = '2.16'


### PR DESCRIPTION
The user can now report a bug by shaking his phone or clicking on the "Report a bug" item in `MoreFragment`. The bug report can be seen on Buglife's dashboard. Furthermore, a notification is also sent to Slack. 
![ezgif-1-a85d2eb31662](https://user-images.githubusercontent.com/22182973/49982462-a5319700-ff2a-11e8-8efe-b40d489acc92.gif)

- Set up Buglife in Android app
- Add some basic fields to form
- Override some strings from Buglife 
- Perform some theming for the dialog

### TODO
- Update reporter's theme (by overriding Buglife's attributes)
- Let user attach his own file
- Handle API key

### Known issues
- The ["What hapened?" string](https://github.com/Buglife/buglife-android/blob/071371ad4b45e6a671338bcfd64f7c0cd18e67b0/src/main/java/com/buglife/sdk/TextInputField.java#L69) is hardcoded and thus cannot be overrided. 
