### PR TITLE
Fix date conversion

### DIFF
--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/domain/FetchSessionsUseCase.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/domain/FetchSessionsUseCase.kt
@@ -15,11 +15,11 @@ Created by mykaelll87 on 17/11/18
  */
 class FetchSessionsUseCase @Inject constructor(
     private val userCredentials: SignetsUserCredentials,
-    private val sessionRespository: SessionRepository,
+    private val sessionRepository: SessionRepository,
     private val app: App
 ) {
     operator fun invoke(): LiveData<Resource<List<Session>>> {
-        return Transformations.map(sessionRespository.getSessions(userCredentials) { true }) {
+        return Transformations.map(sessionRepository.getSessions(userCredentials) { true }) {
             when {
                 it.status == Resource.Status.LOADING -> Resource.loading(it.data.orEmpty())
                 it.status == Resource.Status.ERROR -> Resource.error(it.message ?: app.getString(R.string.error), it.data.orEmpty())

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/grades/GradesViewModel.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/grades/GradesViewModel.kt
@@ -26,13 +26,9 @@ class GradesViewModel @Inject constructor(
     private val fetchGradesCoursesUseCase: FetchGradesCoursesUseCase,
     private val app: App
 ) : ViewModel(), LifecycleObserver {
-    private val coursMediatorLiveData: MediatorLiveData<Resource<Map<String, List<Cours>>>> by lazy {
-        MediatorLiveData<Resource<Map<String, List<Cours>>>>()
-    }
+    private val coursMediatorLiveData: MediatorLiveData<Resource<Map<String, List<Cours>>>> = MediatorLiveData()
     private var coursLiveData: LiveData<Resource<Map<String, List<Cours>>>>? = null
-    val errorMessage: LiveData<Event<String?>> by lazy {
-        Transformations.map(coursMediatorLiveData) { it.getGenericErrorMessage(app) }
-    }
+    val errorMessage: LiveData<Event<String?>> = Transformations.map(coursMediatorLiveData) { it.getGenericErrorMessage(app) }
 
     private val _cours: MutableLiveData<Map<String, List<Cours>>> = MutableLiveData()
     val cours: LiveData<Map<String, List<Cours>>> = _cours

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/GradesDetailsViewModel.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/GradesDetailsViewModel.kt
@@ -33,11 +33,9 @@ class GradesDetailsViewModel @Inject constructor(
 ) : ViewModel(), LifecycleObserver {
     val cours = MutableLiveData<Cours>()
     private var summaryAndEvaluationsRes: LiveData<Resource<SommaireEtEvaluations>>? = null
-    private val summaryAndEvaluationsMediatorLiveData: MediatorLiveData<Resource<SommaireEtEvaluations>> by lazy {
-        MediatorLiveData<Resource<SommaireEtEvaluations>>()
-    }
-    val errorMessage: LiveData<Event<String?>> by lazy {
-        Transformations.map(summaryAndEvaluationsMediatorLiveData) { Event(it.message) }
+    private val summaryAndEvaluationsMediatorLiveData: MediatorLiveData<Resource<SommaireEtEvaluations>> = MediatorLiveData()
+    val errorMessage: LiveData<Event<String?>> = Transformations.map(summaryAndEvaluationsMediatorLiveData) {
+        Event(it.message)
     }
     val recyclerViewItems: LiveData<List<Group>> = Transformations.map(summaryAndEvaluationsMediatorLiveData) {
         fun getSummaryItems(sommaireElementsEvaluation: SommaireElementsEvaluation) = listOf(

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/more/MoreViewModel.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/more/MoreViewModel.kt
@@ -21,17 +21,17 @@ class MoreViewModel @Inject constructor(
     private val app: App
 ) : AndroidViewModel(app) {
 
-    private val logoutMediatorLiveData by lazy { MediatorLiveData<Boolean>() }
+    private val logoutMediatorLiveData = MediatorLiveData<Boolean>()
     val loading: LiveData<Boolean> = Transformations.map(logoutMediatorLiveData) { it }
-    private val _displayLogoutConfirmationDialog by lazy { MutableLiveData<Boolean>() }
+    private val _displayLogoutConfirmationDialog = MutableLiveData<Boolean>()
     val displayLogoutConfirmationDialog: LiveData<Boolean> = _displayLogoutConfirmationDialog
-    private val _displayMessage by lazy { MutableLiveData<Event<String>>() }
+    private val _displayMessage = MutableLiveData<Event<String>>()
     val displayMessage: LiveData<Event<String>> = _displayMessage
-    private val _navigateToLogin by lazy { MutableLiveData<Event<Unit>>() }
+    private val _navigateToLogin = MutableLiveData<Event<Unit>>()
     val navigateToLogin: LiveData<Event<Unit>> = _navigateToLogin
-    private val _navigateToAbout by lazy { MutableLiveData<Event<Unit>>() }
+    private val _navigateToAbout = MutableLiveData<Event<Unit>>()
     val navigateToAbout: LiveData<Event<Unit>> = _navigateToAbout
-    private val _navigateToOpenSourceLicenses by lazy { MutableLiveData<Event<Unit>>() }
+    private val _navigateToOpenSourceLicenses = MutableLiveData<Event<Unit>>()
     val navigateToOpenSourcesLicenses: LiveData<Event<Unit>> = _navigateToOpenSourceLicenses
 
     /**

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/profile/ProfileViewModel.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/profile/ProfileViewModel.kt
@@ -29,16 +29,14 @@ class ProfileViewModel @Inject constructor(
     private val app: App
 ) : ViewModel(), LifecycleObserver {
 
-    private val profileMediatorLiveData: MediatorLiveData<Resource<List<ProfileItem<out ProfileAdapter.ProfileViewHolder>>>> by lazy {
-        MediatorLiveData<Resource<List<ProfileItem<out ProfileAdapter.ProfileViewHolder>>>>()
-    }
+    private val profileMediatorLiveData: MediatorLiveData<Resource<List<ProfileItem<out ProfileAdapter.ProfileViewHolder>>>> = MediatorLiveData()
     val profile: LiveData<List<ProfileItem<out ProfileAdapter.ProfileViewHolder>>> = Transformations.map(profileMediatorLiveData) {
         it.data
     }
     private val _loading = MutableLiveData<Boolean>()
     val loading: LiveData<Boolean> = _loading
-    val errorMessage: LiveData<Event<String?>> by lazy {
-        Transformations.map(profileMediatorLiveData) { it.getGenericErrorMessage(app) }
+    val errorMessage: LiveData<Event<String?>> = Transformations.map(profileMediatorLiveData) {
+        it.getGenericErrorMessage(app)
     }
     private var etudiantProgrammesPair: LiveData<Resource<Pair<Etudiant?, List<Programme>?>>>? = null
 

--- a/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/repository/signets/SeanceRepository.kt
+++ b/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/repository/signets/SeanceRepository.kt
@@ -16,8 +16,7 @@ import ca.etsmtl.applets.repository.data.model.Resource
 import ca.etsmtl.applets.repository.data.model.Seance
 import ca.etsmtl.applets.repository.data.model.Session
 import ca.etsmtl.applets.repository.data.model.SignetsUserCredentials
-import java.text.SimpleDateFormat
-import java.util.Locale
+import ca.etsmtl.applets.repository.util.unixToDefaultSignetsDate
 import javax.inject.Inject
 
 /**
@@ -74,15 +73,14 @@ class SeanceRepository @Inject constructor(
             }
 
             override fun createCall(): LiveData<ApiResponse<ApiSignetsModel<ApiListeDesSeances>>> {
-                val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
                 return api.listeDesSeances(
                         ListeDesSeancesRequestBody(
                                 userCredentials.codeAccesUniversel.value,
                                 userCredentials.motPasse,
                                 cours?.sigle ?: "",
                                 session.abrege,
-                            formatter.format(session.dateDebut),
-                            formatter.format(session.dateFin)
+                            session.dateDebut.unixToDefaultSignetsDate(),
+                            session.dateFin.unixToDefaultSignetsDate()
                         )
                 )
             }

--- a/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/util/DateExt.kt
+++ b/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/util/DateExt.kt
@@ -1,0 +1,53 @@
+package ca.etsmtl.applets.repository.util
+
+import java.text.DateFormat
+import java.text.ParseException
+import java.text.SimpleDateFormat
+import java.util.Date
+
+/**
+ * Created by Sonphil on 09-01-19.
+ */
+
+/**
+ * Formats the [String] which must be in the following format: "yyyy-MM-dd"
+ *
+ * @return The formatted [String] or the [String] (without formatting) if it can't be parsed
+ */
+fun String.toLocaleDate(): String {
+    with (SimpleDateFormat("yyyy-MM-dd")) {
+        return try {
+            DateFormat.getDateInstance().format(parse(this@toLocaleDate))
+        } catch (e: ParseException) {
+            e.printStackTrace()
+            this@toLocaleDate
+        }
+    }
+}
+
+/**
+ * Formats Microsoft JSON date (e.g. /Date(1525093200000)/) to Unix time (e.g. 1525093200000)
+ */
+internal fun String.msDateToUnix() = substringAfter('(').substringBefore(')').toLong()
+
+/**
+ * Convert date [String] to Unix time in seconds
+ *
+ * @param format The current format of the date (e.g. yyyy-MM-dd)
+ */
+fun String.dateToUnix(format: String): Long {
+    return try {
+        SimpleDateFormat(format).parse(this@dateToUnix).time
+    } catch (e: Exception) {
+        e.printStackTrace()
+        0
+    }
+}
+
+internal fun String.signetsDefaultDateToUnix(): Long = dateToUnix("yyyy-MM-dd")
+
+/**
+ * Format unix date in seconds to Signets default date format
+ */
+internal fun Long.unixToDefaultSignetsDate() = SimpleDateFormat("yyyy-MM-dd")
+    .format(Date(this))

--- a/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/util/StringExt.kt
+++ b/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/util/StringExt.kt
@@ -1,9 +1,5 @@
 package ca.etsmtl.applets.repository.util
 
-import java.text.DateFormat
-import java.text.ParseException
-import java.text.SimpleDateFormat
-
 /**
  * Created by Sonphil on 09-09-18.
  */
@@ -35,49 +31,3 @@ fun String.replaceCommaAndParseToFloat() = replaceFirst(",", ".").toFloatOrNull(
  * If the [String] is not a valid representation of a number, then, O.0 is returned.
  */
 fun String.replaceCommaAndParseToDouble() = replaceFirst(",", ".").toDoubleOrNull() ?: 0.0
-
-/**
- * Formats the [String] which must be in the following format: "yyyy-MM-dd"
- *
- * @return The formatted [String] or the [String] (without formatting) if it can't be parsed
- */
-fun String.toLocaleDate(): String {
-    with (SimpleDateFormat("yyyy-MM-dd")) {
-        return try {
-            DateFormat.getDateInstance().format(parse(this@toLocaleDate))
-        } catch (e: ParseException) {
-            e.printStackTrace()
-            this@toLocaleDate
-        }
-    }
-}
-
-/**
- * Formats Microsoft JSON date (e.g. /Date(1525093200000)/) to Unix time (e.g. 1525093200000)
- */
-fun String.msDateToUnix() = substringAfter('(').substringBefore(')').toLong()
-
-/**
- * Convert date [String] to Unix time
- *
- * @param format The current format of the date (e.g. dd-MM-yyyy)
- */
-fun String.dateToUnix(format: String): Long {
-    return this@dateToUnix.dateToUnixInMs(format) / 1000
-}
-
-/**
- * Convert date [String] to Unix time, in miliseconds
- *
- * @param format The current format of the date (e.g. dd-MM-yyyy)
- */
-fun String.dateToUnixInMs(format: String): Long {
-    return try {
-        SimpleDateFormat(format).parse(this@dateToUnixInMs).time
-    } catch (e: Exception) {
-        e.printStackTrace()
-        0
-    }
-}
-
-internal fun String.signetsDefaultDateToUnix(): Long = dateToUnix("dd-MM-yyyy")


### PR DESCRIPTION
- dd-MM-yyyy was used instead of yyyy-MM-dd
- Remove `dateToUnixInMs`. Unix times used in the app should be in seconds.
- Move extensions functions related to date to DateExt file
- Remove lazy keyword that was used for some LiveData. It was not needed.