### PR TITLE
Add livedata-ktx and RefreshableLiveData

### DIFF
--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/GradesDetailsFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/GradesDetailsFragment.kt
@@ -72,7 +72,7 @@ class GradesDetailsFragment : DaggerFragment() {
     }
 
     private fun subscribeUI() {
-        gradesDetailsViewModel.getLoading().observe(this, Observer {
+        gradesDetailsViewModel.loading.observe(this, Observer {
             swipeRefreshLayoutGradesDetails.isRefreshing = it == true
         })
 

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/GradesDetailsViewModel.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/GradesDetailsViewModel.kt
@@ -17,7 +17,6 @@ import ca.etsmtl.applets.repository.data.model.Evaluation
 import ca.etsmtl.applets.repository.data.model.Resource
 import ca.etsmtl.applets.repository.data.model.SommaireElementsEvaluation
 import ca.etsmtl.applets.repository.data.model.SommaireEtEvaluations
-import ca.etsmtl.applets.repository.util.zeroIfNullOrBlank
 import com.shopify.livedataktx.map
 import com.shopify.livedataktx.nonNull
 import com.xwray.groupie.ExpandableGroup
@@ -84,11 +83,11 @@ class GradesDetailsViewModel @Inject constructor(
             val gradeAverageItem = it.sommaireElementsEvaluation.run {
                 GradeAverageItem(
                     cours.value?.cote,
-                    note.zeroIfNullOrBlank(),
-                    noteSur.zeroIfNullOrBlank(),
-                    noteSur100.zeroIfNullOrBlank(),
-                    moyenneClasse.zeroIfNullOrBlank(),
-                    moyenneClassePourcentage.zeroIfNullOrBlank()
+                    note,
+                    noteSur,
+                    noteSur100,
+                    moyenneClasse,
+                    moyenneClassePourcentage
                 )
             }
 
@@ -103,16 +102,16 @@ class GradesDetailsViewModel @Inject constructor(
                     ExpandableGroup(EvaluationHeaderItem(it)).apply {
                         val grade = String.format(
                             app.getString(R.string.text_grade_with_percentage),
-                            it.note.zeroIfNullOrBlank(),
-                            it.corrigeSur.zeroIfNullOrBlank(),
-                            it.notePourcentage.zeroIfNullOrBlank()
+                            it.note,
+                            it.corrigeSur,
+                            it.notePourcentage
                         )
 
                         val averageStr = String.format(
                             app.getString(R.string.text_grade_with_percentage),
-                            it.moyenne.zeroIfNullOrBlank(),
-                            it.corrigeSur.zeroIfNullOrBlank(),
-                            it.moyennePourcentage.zeroIfNullOrBlank()
+                            it.moyenne,
+                            it.corrigeSur,
+                            it.moyennePourcentage
                         )
 
                         add(Section(getEvaluationDetailItems(grade, averageStr, it)))

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/GradesDetailsViewModel.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/GradesDetailsViewModel.kt
@@ -3,7 +3,6 @@ package ca.etsmtl.applets.etsmobile.presentation.gradesdetails
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.Transformations
@@ -12,12 +11,15 @@ import ca.etsmtl.applets.etsmobile.R
 import ca.etsmtl.applets.etsmobile.domain.FetchGradesDetailsUseCase
 import ca.etsmtl.applets.etsmobile.presentation.App
 import ca.etsmtl.applets.etsmobile.util.Event
+import ca.etsmtl.applets.etsmobile.util.RefreshableLiveData
 import ca.etsmtl.applets.repository.data.model.Cours
 import ca.etsmtl.applets.repository.data.model.Evaluation
 import ca.etsmtl.applets.repository.data.model.Resource
 import ca.etsmtl.applets.repository.data.model.SommaireElementsEvaluation
 import ca.etsmtl.applets.repository.data.model.SommaireEtEvaluations
 import ca.etsmtl.applets.repository.util.zeroIfNullOrBlank
+import com.shopify.livedataktx.map
+import com.shopify.livedataktx.nonNull
 import com.xwray.groupie.ExpandableGroup
 import com.xwray.groupie.Group
 import com.xwray.groupie.Section
@@ -32,54 +34,61 @@ class GradesDetailsViewModel @Inject constructor(
     private val app: App
 ) : ViewModel(), LifecycleObserver {
     val cours = MutableLiveData<Cours>()
-    private var summaryAndEvaluationsRes: LiveData<Resource<SommaireEtEvaluations>>? = null
-    private val summaryAndEvaluationsMediatorLiveData: MediatorLiveData<Resource<SommaireEtEvaluations>> = MediatorLiveData()
-    val errorMessage: LiveData<Event<String?>> = Transformations.map(summaryAndEvaluationsMediatorLiveData) {
-        Event(it.message)
+    private val summaryAndEvaluations = object : RefreshableLiveData<Resource<SommaireEtEvaluations>>() {
+        override fun updateSource(): LiveData<Resource<SommaireEtEvaluations>> {
+            return Transformations.switchMap(cours) {
+                fetchGradesDetailsUseCase(it)
+            }
+        }
     }
-    val recyclerViewItems: LiveData<List<Group>> = Transformations.map(summaryAndEvaluationsMediatorLiveData) {
+    val errorMessage: LiveData<Event<String?>> = summaryAndEvaluations
+        .nonNull()
+        .map {
+            Event(it.message)
+        }
+    val recyclerViewItems: LiveData<List<Group>> = Transformations.map(summaryAndEvaluations) {
         fun getSummaryItems(sommaireElementsEvaluation: SommaireElementsEvaluation) = listOf(
-                EvaluationDetailItem(app.getString(R.string.label_median), sommaireElementsEvaluation.medianeClasse),
-                EvaluationDetailItem(app.getString(R.string.label_standard_deviation), sommaireElementsEvaluation.ecartTypeClasse),
-                EvaluationDetailItem(app.getString(R.string.label_percentile_rank), sommaireElementsEvaluation.rangCentileClasse)
+            EvaluationDetailItem(app.getString(R.string.label_median), sommaireElementsEvaluation.medianeClasse),
+            EvaluationDetailItem(app.getString(R.string.label_standard_deviation), sommaireElementsEvaluation.ecartTypeClasse),
+            EvaluationDetailItem(app.getString(R.string.label_percentile_rank), sommaireElementsEvaluation.rangCentileClasse)
         )
 
         fun getEvaluationDetailItems(grade: String, average: String, evaluation: Evaluation) = listOf(
-                EvaluationDetailItem(
-                        app.getString(R.string.label_grade),
-                        grade
-                ),
-                EvaluationDetailItem(
-                        app.getString(R.string.label_average),
-                        average
-                ),
-                EvaluationDetailItem(
-                        app.getString(R.string.label_median),
-                        evaluation.mediane
-                ),
-                EvaluationDetailItem(
-                        app.getString(R.string.label_standard_deviation),
-                        evaluation.ecartType
-                ),
-                EvaluationDetailItem(
-                        app.getString(R.string.label_percentile_rank),
-                        evaluation.rangCentile
-                ),
-                EvaluationDetailItem(
-                        app.getString(R.string.label_target_date),
-                        evaluation.dateCible
-                )
+            EvaluationDetailItem(
+                app.getString(R.string.label_grade),
+                grade
+            ),
+            EvaluationDetailItem(
+                app.getString(R.string.label_average),
+                average
+            ),
+            EvaluationDetailItem(
+                app.getString(R.string.label_median),
+                evaluation.mediane
+            ),
+            EvaluationDetailItem(
+                app.getString(R.string.label_standard_deviation),
+                evaluation.ecartType
+            ),
+            EvaluationDetailItem(
+                app.getString(R.string.label_percentile_rank),
+                evaluation.rangCentile
+            ),
+            EvaluationDetailItem(
+                app.getString(R.string.label_target_date),
+                evaluation.dateCible
+            )
         )
 
         it?.takeIf { it.status != Resource.Status.LOADING }?.data?.let {
             val gradeAverageItem = it.sommaireElementsEvaluation.run {
                 GradeAverageItem(
-                        cours.value?.cote,
-                        note.zeroIfNullOrBlank(),
-                        noteSur.zeroIfNullOrBlank(),
-                        noteSur100.zeroIfNullOrBlank(),
-                        moyenneClasse.zeroIfNullOrBlank(),
-                        moyenneClassePourcentage.zeroIfNullOrBlank()
+                    cours.value?.cote,
+                    note.zeroIfNullOrBlank(),
+                    noteSur.zeroIfNullOrBlank(),
+                    noteSur100.zeroIfNullOrBlank(),
+                    moyenneClasse.zeroIfNullOrBlank(),
+                    moyenneClassePourcentage.zeroIfNullOrBlank()
                 )
             }
 
@@ -93,17 +102,17 @@ class GradesDetailsViewModel @Inject constructor(
                 val evaluationsItems = it.evaluations.map {
                     ExpandableGroup(EvaluationHeaderItem(it)).apply {
                         val grade = String.format(
-                                app.getString(R.string.text_grade_with_percentage),
-                                it.note.zeroIfNullOrBlank(),
-                                it.corrigeSur.zeroIfNullOrBlank(),
-                                it.notePourcentage.zeroIfNullOrBlank()
+                            app.getString(R.string.text_grade_with_percentage),
+                            it.note.zeroIfNullOrBlank(),
+                            it.corrigeSur.zeroIfNullOrBlank(),
+                            it.notePourcentage.zeroIfNullOrBlank()
                         )
 
                         val averageStr = String.format(
-                                app.getString(R.string.text_grade_with_percentage),
-                                it.moyenne.zeroIfNullOrBlank(),
-                                it.corrigeSur.zeroIfNullOrBlank(),
-                                it.moyennePourcentage.zeroIfNullOrBlank()
+                            app.getString(R.string.text_grade_with_percentage),
+                            it.moyenne.zeroIfNullOrBlank(),
+                            it.corrigeSur.zeroIfNullOrBlank(),
+                            it.moyennePourcentage.zeroIfNullOrBlank()
                         )
 
                         add(Section(getEvaluationDetailItems(grade, averageStr, it)))
@@ -114,31 +123,18 @@ class GradesDetailsViewModel @Inject constructor(
             }
         }
     }
-    val showEmptyView: LiveData<Boolean> = Transformations.map(summaryAndEvaluationsMediatorLiveData) {
-        (it.status != Resource.Status.LOADING && (it?.data?.evaluations == null || it.data?.evaluations?.isEmpty() == true))
-    }
-
-    fun getLoading(): LiveData<Boolean> = Transformations.map(summaryAndEvaluationsMediatorLiveData) {
-        it.status == Resource.Status.LOADING
-    }
-
-    private fun load() {
-        cours.value?.let {
-            summaryAndEvaluationsRes = fetchGradesDetailsUseCase(it).apply {
-                summaryAndEvaluationsMediatorLiveData.addSource(this) {
-                    summaryAndEvaluationsMediatorLiveData.value = it
-                }
-            }
+    val showEmptyView: LiveData<Boolean> = summaryAndEvaluations
+        .nonNull()
+        .map {
+            (it.status != Resource.Status.LOADING && (it?.data?.evaluations == null || it.data?.evaluations?.isEmpty() == true))
         }
-    }
+
+    val loading: LiveData<Boolean> = summaryAndEvaluations
+        .nonNull()
+        .map {
+            it.status == Resource.Status.LOADING
+        }
 
     @OnLifecycleEvent(Lifecycle.Event.ON_START)
-    fun refresh() {
-        summaryAndEvaluationsRes?.let {
-            summaryAndEvaluationsMediatorLiveData.removeSource(it)
-            summaryAndEvaluationsRes = null
-        }
-
-        load()
-    }
+    fun refresh() = summaryAndEvaluations.refresh()
 }

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/util/RefreshableLiveData.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/util/RefreshableLiveData.kt
@@ -1,0 +1,28 @@
+package ca.etsmtl.applets.etsmobile.util
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+
+/**
+ * Created by Sonphil on 10-01-19.
+ */
+
+abstract class RefreshableLiveData<T> : MediatorLiveData<T>() {
+    private var source: LiveData<T>? = null
+        set(value) {
+            field?.let { removeSource(it) }
+            field = value
+        }
+
+    fun refresh() {
+        updateSource().let {
+            source = it
+
+            addSource(it) { value ->
+                this.value = value
+            }
+        }
+    }
+
+    abstract fun updateSource(): LiveData<T>
+}

--- a/android/repository/build.gradle
+++ b/android/repository/build.gradle
@@ -103,4 +103,7 @@ dependencies {
     // Chuck
     debugImplementation "com.readystatesoftware.chuck:library:$chuck"
     releaseImplementation "com.readystatesoftware.chuck:library-no-op:$chuck"
+
+    // livedata-ktx
+    api "com.shopify:livedata-ktx:2.0.1"
 }

--- a/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/db/entity/mapper/SignetsDbMapperExt.kt
+++ b/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/db/entity/mapper/SignetsDbMapperExt.kt
@@ -20,6 +20,7 @@ import ca.etsmtl.applets.repository.data.model.Programme
 import ca.etsmtl.applets.repository.data.model.Seance
 import ca.etsmtl.applets.repository.data.model.Session
 import ca.etsmtl.applets.repository.data.model.SommaireElementsEvaluation
+import ca.etsmtl.applets.repository.util.zeroIfNullOrBlank
 import java.util.Date
 
 /**
@@ -55,12 +56,12 @@ fun EvaluationEntity.toEvaluation() = Evaluation(
         this.nom,
         this.equipe,
         this.dateCible,
-        this.note,
-        this.corrigeSur,
-        this.notePourcentage,
+        this.note.zeroIfNullOrBlank(),
+        this.corrigeSur.zeroIfNullOrBlank(),
+        this.notePourcentage.zeroIfNullOrBlank(),
         this.ponderation,
-        this.moyenne,
-        this.moyennePourcentage,
+        this.moyenne.zeroIfNullOrBlank(),
+        this.moyennePourcentage.zeroIfNullOrBlank(),
         this.ecartType,
         this.mediane,
         this.rangCentile,
@@ -137,18 +138,18 @@ fun SeanceEntity.toSeance() = Seance(
 fun List<SeanceEntity>.toSeances(): List<Seance> = map { it.toSeance() }
 
 fun SommaireElementsEvaluationEntity.toSommaireEvaluation() = SommaireElementsEvaluation(
-        this.sigleCours,
-        this.session,
-        this.note,
-        this.noteSur,
-        this.noteSur100,
-        this.moyenneClasse,
-        this.moyenneClassePourcentage,
-        this.ecartTypeClasse,
-        this.medianeClasse,
-        this.rangCentileClasse,
-        this.noteACeJourElementsIndividuels,
-        this.noteSur100PourElementsIndividuels
+        sigleCours,
+        session,
+        note.zeroIfNullOrBlank(),
+        noteSur.zeroIfNullOrBlank(),
+        noteSur100.zeroIfNullOrBlank(),
+        moyenneClasse.zeroIfNullOrBlank(),
+        moyenneClassePourcentage.zeroIfNullOrBlank(),
+        ecartTypeClasse,
+        medianeClasse,
+        rangCentileClasse,
+        noteACeJourElementsIndividuels,
+        noteSur100PourElementsIndividuels
 )
 
 fun SessionEntity.toSession() = Session(


### PR DESCRIPTION
#### Add `RefreshableLiveData`
The code for refreshing `LiveData`s was duplicated in many ViewModel. The pattern is now defined in a class called  `RefreshableLiveData`. For now, it's only used in `GradesDetailsViewModel `.

#### Add [livedata-ktx](https://github.com/Shopify/livedata-ktx)
It's a library that provide Kotlin extensions for `LiveData`.