### PR TITLE
Bump Gradle version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,7 +40,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath "com.android.tools.build:gradle:$gradle_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:3.2.0"
         classpath 'io.fabric.tools:gradle:1.26.1'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlin_version = '1.3.11'
-    ext.gradle_version = '3.2.1'
+    ext.gradle_version = '3.3.0'
     repositories {
         google()
         jcenter()

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,5 @@ org.gradle.jvmargs=-Xmx1536m
 android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true
+
+android.proguard.enableRulesExtraction=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Nov 27 20:26:22 EST 2018
+#Mon Jan 14 14:09:46 EST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
android.proguard.enableRulesExtraction has been set to false
cf. https://github.com/square/moshi/issues/738#issuecomment-453024615

> Proguard 6.1.0beta2 is out. Here is a summary of the workarounds:
> 
> ## AGP 3.2.x
> Copy the proguard rules to your project like described in [this comment](https://github.com/square/moshi/issues/738#issuecomment-437281870).
> 
> ## AGP 3.3.x
> Set `android.proguard.enableRulesExtraction=false` and then copy the proguard rules to your project like described in [this comment](https://github.com/square/moshi/issues/738#issuecomment-437281870).
> 
> OR
> 
> Upgrade proguard to 6.1.0beta2:
> 
> ```
> buildscript {
>     configurations.all {
>         resolutionStrategy {
>             force 'net.sf.proguard:proguard-gradle:6.1.0beta2'
>         }
>     }
> }
> ```
> OR
> 
> Enable R8 by setting `android.enableR8=true`.
> 
> ## AGP 3.4.x
> Should work by default. If you disabled R8 follow the instructions for AGP 3.3.

