### PR TITLE
Limit progress view grades

### DIFF
--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/EvaluationHeaderItem.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/EvaluationHeaderItem.kt
@@ -54,9 +54,7 @@ class EvaluationHeaderItem(private val evaluation: Evaluation) : Item(), Expanda
                         .replaceFirst(",", ".")
                         .toFloat()
 
-                if (grade > 100) {
-                    grade = 100f
-                }
+                grade = grade.coerceIn(0f, 100f)
 
                 setEndProgress(grade)
 

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/GradeAverageItem.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/gradesdetails/GradeAverageItem.kt
@@ -102,7 +102,7 @@ class GradeAverageItem(
         animate: Boolean
     ) {
         with(circleProgressView) {
-            setEndProgress(progress)
+            setEndProgress(progress.coerceIn(0f, 100f))
 
             if (animate) {
                 startProgressAnimation()


### PR DESCRIPTION
The ProgressView for the average could crash if the value was not from between 0 and 100.