### PR TITLE
Integrate status bar into circular reveal animation

### DIFF
--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/main/MainActivity.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/main/MainActivity.kt
@@ -27,7 +27,8 @@ class MainActivity : BaseActivity() {
         R.id.fragmentSchedule,
         R.id.fragmentStudent,
         R.id.fragmentEts,
-        R.id.fragmentMore
+        R.id.fragmentMore,
+        R.id.fragmentAbout
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/util/ResourcesExt.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/util/ResourcesExt.kt
@@ -1,0 +1,17 @@
+package ca.etsmtl.applets.etsmobile.util
+
+import android.content.res.Resources
+
+/**
+ * Created by Sonphil on 17-01-19.*
+ */
+
+fun Resources.getAndroidDimensionInPixelSize(name: String): Int? {
+    val resourceId = getIdentifier(name, "dimen", "android")
+
+    return if (resourceId > 0) {
+        getDimensionPixelSize(resourceId)
+    } else {
+        null
+    }
+}

--- a/android/app/src/main/res/layout/fragment_about.xml
+++ b/android/app/src/main/res/layout/fragment_about.xml
@@ -12,11 +12,12 @@
         android:id="@+id/backgroundAbout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/bgApplets"
+        android:background="@color/applets"
         android:visibility="invisible"
         tools:visibility="visible" />
 
     <LinearLayout
+        android:id="@+id/content"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">

--- a/android/app/src/main/res/navigation/nav_graph_main.xml
+++ b/android/app/src/main/res/navigation/nav_graph_main.xml
@@ -52,7 +52,8 @@
         tools:layout="@layout/fragment_more">
         <action
             android:id="@+id/action_fragmentMore_to_fragmentAbout"
-            app:destination="@id/fragmentAbout" />
+            app:destination="@id/fragmentAbout"
+            app:popUpTo="@id/fragmentMore" />
         <action
             android:id="@+id/action_fragmentMore_to_fragmentLogin"
             app:destination="@id/fragmentLogin" />
@@ -63,6 +64,5 @@
         tools:layout="@layout/fragment_about" />
     <activity
         android:id="@+id/activityOpenSourceLicenses"
-        android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity">
-    </activity>
+        android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity" />
 </navigation>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -12,7 +12,7 @@
     <color name="etsGrisClair">#807F83</color>
     <color name="etsNoir">#2E2A25</color>
 
-    <color name="bgApplets">#003462</color>
+    <color name="applets">#003462</color>
 
     <color name="failureGradeMinColor">#D32F2F</color>
     <color name="failureGradeMaxColor">#FF7043</color>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -11,6 +11,7 @@
         <item name="android:textColorPrimary">@android:color/primary_text_light</item>
         <item name="android:textColorPrimaryInverse">@android:color/primary_text_light</item>
         <item name="android:homeAsUpIndicator">@drawable/ic_arrow_back_white_24dp</item>
+        <item name="android:statusBarColor">?android:attr/colorPrimaryDark</item>
     </style>
 
     <style name="SplashTheme" parent="AppTheme">
@@ -76,8 +77,8 @@
 
     <!-- About screen theme -->
     <style name="AboutTheme" parent="AppTheme">
-        <item name="colorPrimary">@color/bgApplets</item>
-        <item name="colorPrimaryDark">@color/bgApplets</item>
+        <item name="colorPrimary">@color/applets</item>
+        <item name="colorPrimaryDark">@color/applets</item>
         <item name="colorControlNormal">@android:color/white</item>
         <item name="colorControlActivated">@android:color/white</item>
         <item name="colorControlHighlight">@android:color/white</item>


### PR DESCRIPTION
After:
![ezgif-1-0df7e711c1b0](https://user-images.githubusercontent.com/22182973/51309300-11b02200-1a12-11e9-838f-f0c5a654fec1.gif)

Before:
![ezgif-1-a398fb7ee64d](https://user-images.githubusercontent.com/22182973/51309832-42dd2200-1a13-11e9-9aa5-197f23e81ef4.gif)

`WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS` only set if the orientation is in portrait mode. In landscape, you must know if the navigation bar is on the left or the right and adjust the layout start or end margin accordingly. In landscape, for now, the navigation bar is not integrated into the animation.