### PR TITLE
Bump Kotlin and Navigation Components version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: "org.jlleitschuh.gradle.ktlint"
 apply plugin: 'io.fabric'
-apply plugin: "androidx.navigation.safeargs"
+apply plugin: 'androidx.navigation.safeargs.kotlin'
 apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 
 def keystorePropertiesFile = rootProject.file("android/keystore.properties")
@@ -129,9 +129,6 @@ dependencies {
 
     // AndroidJUnitRunner and JUnit Rules
     androidTestImplementation 'androidx.test:rules:1.1.1'
-
-    // Android Navigation Test Helpers
-    androidTestImplementation "android.arch.navigation:navigation-testing:$navigation"
 
     // Assertions
     androidTestImplementation 'androidx.test.ext:junit:1.1.0'

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/more/MoreFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/more/MoreFragment.kt
@@ -81,7 +81,7 @@ class MoreFragment : DaggerFragment() {
             iconView to getString(R.string.transition_about_applets_logo)
         )
 
-        findNavController().navigate(MoreFragmentDirections.ActionFragmentMoreToFragmentAbout(), extras)
+        findNavController().navigate(MoreFragmentDirections.actionFragmentMoreToFragmentAbout(), extras)
     }
 
     private fun subscribeUI() {
@@ -103,7 +103,7 @@ class MoreFragment : DaggerFragment() {
             with (activity as MainActivity) {
                 appBarLayout.setExpanded(false, false)
                 bottomNavigationView.toggle(false)
-                findNavController().navigate(MoreFragmentDirections.ActionFragmentMoreToFragmentLogin())
+                findNavController().navigate(MoreFragmentDirections.actionFragmentMoreToFragmentLogin())
             }
         })
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     ext.mockito = '2.23.4'
     ext.mockito_kotlin = '1.6.0'
     ext.moshi = '1.8.0'
-    ext.navigation = '1.0.0-alpha08'
+    ext.navigation = '1.0.0-alpha11'
     ext.okhttp = '3.8.0'
     ext.recyclerviewanimators = '2.3.0'
     ext.retrofit = '2.5.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.11'
+    ext.kotlin_version = '1.3.20'
     ext.gradle_version = '3.3.0'
     repositories {
         google()


### PR DESCRIPTION
- Use androidx.navigation.safeargs.kotlin plugin because the Android app only use Kotlin
- Remove Android Navigation Test Helpers. They are not needed and unavailable in the latest versions.