### PR TITLE
Fix build issue caused by Klock

### DIFF
--- a/android/repository/build.gradle
+++ b/android/repository/build.gradle
@@ -91,5 +91,10 @@ dependencies {
     // livedata-ktx
     api "com.shopify:livedata-ktx:2.0.1"
 
-    api project(':shared')
+    // Klock
+    api "com.soywiz:klock-jvm:1.1.1"
+
+    api (project(':shared')) {
+        exclude module: 'klock'
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.20'
+    ext.kotlin_version = '1.3.21'
     ext.gradle_version = '3.3.0'
     repositories {
         google()

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -25,6 +25,7 @@ kotlin {
             dependencies {
                 api 'org.jetbrains.kotlin:kotlin-stdlib-common'
                 implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.10.0"
+                api "com.soywiz:klock:1.1.1"
             }
         }
 
@@ -35,6 +36,7 @@ kotlin {
                 api 'org.jetbrains.kotlin:kotlin-stdlib-jdk7'
             }
         }
+
         iOSMain {
             dependsOn commonMain
             dependencies {
@@ -42,10 +44,6 @@ kotlin {
             }
         }
     }
-}
-
-dependencies {
-    api "com.soywiz:klock:1.1.1"
 }
 
 // workaround for https://youtrack.jetbrains.com/issue/KT-27170


### PR DESCRIPTION
- Move `com.soywiz:klock:1.1.1` to `commonMain` block in shared module's `build.gradle`
- Exclude Klock in Android module's `build.gradle` to avoid conflict