### PR TITLE
Expose DashboardViewModel's Channel's as ReceiveChannel's

### DIFF
--- a/shared/src/commonMain/kotlin/presentation/DashboardViewModel.kt
+++ b/shared/src/commonMain/kotlin/presentation/DashboardViewModel.kt
@@ -2,6 +2,7 @@ package presentation
 
 import data.domain.DashboardCardsUseCase
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.launch
 import model.DashboardCard
 
@@ -10,8 +11,10 @@ import model.DashboardCard
  */
 
 class DashboardViewModel(private val dashboardCardsUseCase: DashboardCardsUseCase) : ViewModel() {
-    val cardsChannel = Channel<List<DashboardCard>>()
-    val showUndoRemoveChannel = Channel<Boolean>()
+    private val _cardsChannel = Channel<List<DashboardCard>>()
+    val cardsChannel: ReceiveChannel<List<DashboardCard>> = _cardsChannel
+    private val _showUndoRemoveChannel = Channel<Boolean>()
+    val showUndoRemoveChannel: ReceiveChannel<Boolean> = _showUndoRemoveChannel
 
     private var visibleCards: MutableList<DashboardCard> = mutableListOf()
     private var hiddenCards: MutableList<DashboardCard> = mutableListOf()
@@ -30,12 +33,12 @@ class DashboardViewModel(private val dashboardCardsUseCase: DashboardCardsUseCas
             hiddenCards = cards.second.toMutableList()
         }
 
-        this@DashboardViewModel.cardsChannel.send(visibleCards.toList())
+        this@DashboardViewModel._cardsChannel.send(visibleCards.toList())
     }
 
     fun onCardMoved(fromPosition: Int, toPosition: Int) {
         visibleCards[fromPosition] = visibleCards.set(toPosition, visibleCards[fromPosition])
-        cardsChannel.offer(visibleCards.toList())
+        _cardsChannel.offer(visibleCards.toList())
     }
 
     fun onCardRemoved(position: Int) {
@@ -46,9 +49,9 @@ class DashboardViewModel(private val dashboardCardsUseCase: DashboardCardsUseCas
         hiddenCards.add(removedCard)
         lastRemovedCardPosition = position
 
-        cardsChannel.offer(visibleCards.toList())
+        _cardsChannel.offer(visibleCards.toList())
 
-        showUndoRemoveChannel.offer(true)
+        _showUndoRemoveChannel.offer(true)
     }
 
     fun undoLastRemove() {
@@ -58,7 +61,7 @@ class DashboardViewModel(private val dashboardCardsUseCase: DashboardCardsUseCas
 
         removedCard.visible = true
         visibleCards.add(lastRemovedCardPosition, removedCard)
-        cardsChannel.offer(visibleCards.toList())
+        _cardsChannel.offer(visibleCards.toList())
     }
 
     fun save() = dashboardCardsUseCase.save(


### PR DESCRIPTION
As was the case for `LiveData` and `MutableLiveData` on Android, the ViewModel should expose `Channel`s as `ReceiveChannel`s, so that the user can't send data to the `Channel`.