### PR TITLE
Set BottomNavigationView visibility to invisible

### DIFF
--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/extension/BottomNavigationViewExt.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/extension/BottomNavigationViewExt.kt
@@ -9,7 +9,7 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
  *
  */
 
-fun BottomNavigationView.toggle(show: Boolean, duration: Long = 200) {
+fun BottomNavigationView.setVisible(show: Boolean, duration: Long = 200) {
     clearAnimation()
     animate()
         .translationY(when (show) {

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/about/AboutFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/about/AboutFragment.kt
@@ -19,7 +19,7 @@ import ca.etsmtl.applets.etsmobile.presentation.main.MainActivity
 import ca.etsmtl.applets.etsmobile.extension.getAndroidDimensionInPixelSize
 import ca.etsmtl.applets.etsmobile.extension.getColorCompat
 import ca.etsmtl.applets.etsmobile.extension.open
-import ca.etsmtl.applets.etsmobile.extension.toggle
+import ca.etsmtl.applets.etsmobile.extension.setVisible
 import kotlinx.android.synthetic.main.activity_main.appBarLayout
 import kotlinx.android.synthetic.main.activity_main.bottomNavigationView
 import kotlinx.android.synthetic.main.fragment_about.backgroundAbout
@@ -128,7 +128,7 @@ class AboutFragment : Fragment() {
     private fun setInitialActivityState() {
         (activity as? MainActivity)?.let {
             it.appBarLayout.setExpanded(false, true)
-            it.bottomNavigationView.toggle(false)
+            it.bottomNavigationView.setVisible(false)
             it.window.apply {
                 if (resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
                     setFlags(
@@ -145,7 +145,7 @@ class AboutFragment : Fragment() {
     private fun restoreActivityState() {
         (activity as? MainActivity)?.let {
             it.appBarLayout.setExpanded(true, true)
-            it.bottomNavigationView.toggle(true)
+            it.bottomNavigationView.setVisible(true)
             it.window.apply {
                 clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
                 statusBarColor = it.getColorCompat(R.color.colorPrimaryDark)

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/dashboard/DashboardFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/dashboard/DashboardFragment.kt
@@ -16,7 +16,7 @@ import ca.etsmtl.applets.etsmobile.presentation.dashboard.card.DashboardCardAdap
 import ca.etsmtl.applets.etsmobile.presentation.dashboard.card.DashboardCardsTouchHelperCallback
 import ca.etsmtl.applets.etsmobile.presentation.main.MainActivity
 import ca.etsmtl.applets.etsmobile.extension.toLiveData
-import ca.etsmtl.applets.etsmobile.extension.toggle
+import ca.etsmtl.applets.etsmobile.extension.setVisible
 import com.google.android.material.snackbar.Snackbar
 import dagger.android.support.DaggerFragment
 import kotlinx.android.synthetic.main.activity_main.appBarLayout
@@ -73,7 +73,7 @@ class DashboardFragment : DaggerFragment() {
 
         with(activity as MainActivity) {
             appBarLayout.setExpanded(true, true)
-            bottomNavigationView.toggle(true)
+            bottomNavigationView.setVisible(true)
         }
 
         setupRecyclerView()

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/login/LoginFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/login/LoginFragment.kt
@@ -20,7 +20,7 @@ import ca.etsmtl.applets.etsmobile.extension.fadeTo
 import ca.etsmtl.applets.etsmobile.extension.getColorCompat
 import ca.etsmtl.applets.etsmobile.extension.hideKeyboard
 import ca.etsmtl.applets.etsmobile.extension.open
-import ca.etsmtl.applets.etsmobile.extension.toggle
+import ca.etsmtl.applets.etsmobile.extension.setVisible
 import com.bumptech.glide.Glide
 import com.google.android.material.textfield.TextInputLayout
 import dagger.android.support.DaggerFragment
@@ -88,7 +88,7 @@ class LoginFragment : DaggerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        (activity as MainActivity).bottomNavigationView.toggle(false, 0)
+        (activity as MainActivity).bottomNavigationView.setVisible(false, 0)
 
         Glide.with(this).load(R.drawable.ets_blanc_impr_fond_transparent).into(iVETSLogo)
 

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/more/MoreFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/more/MoreFragment.kt
@@ -15,7 +15,7 @@ import androidx.navigation.fragment.findNavController
 import ca.etsmtl.applets.etsmobile.R
 import ca.etsmtl.applets.etsmobile.presentation.main.MainActivity
 import ca.etsmtl.applets.etsmobile.util.EventObserver
-import ca.etsmtl.applets.etsmobile.extension.toggle
+import ca.etsmtl.applets.etsmobile.extension.setVisible
 import dagger.android.support.DaggerFragment
 import kotlinx.android.synthetic.main.activity_main.appBarLayout
 import kotlinx.android.synthetic.main.activity_main.bottomNavigationView
@@ -102,7 +102,7 @@ class MoreFragment : DaggerFragment() {
         moreViewModel.navigateToLogin.observe(this, EventObserver {
             with(activity as MainActivity) {
                 appBarLayout.setExpanded(false, false)
-                bottomNavigationView.toggle(false)
+                bottomNavigationView.setVisible(false)
                 findNavController().navigate(MoreFragmentDirections.actionFragmentMoreToFragmentLogin())
             }
         })

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/security/SecurityDetailFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/security/SecurityDetailFragment.kt
@@ -12,7 +12,7 @@ import androidx.navigation.fragment.navArgs
 import androidx.navigation.ui.setupWithNavController
 import ca.etsmtl.applets.etsmobile.R
 import ca.etsmtl.applets.etsmobile.presentation.main.MainActivity
-import ca.etsmtl.applets.etsmobile.extension.toggle
+import ca.etsmtl.applets.etsmobile.extension.setVisible
 import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.fragment_security_detail.*
 
@@ -64,7 +64,7 @@ class SecurityDetailFragment : Fragment() {
     }
 
     private fun setInitialActivityState() {
-        (activity as? MainActivity)?.bottomNavigationView?.toggle(false)
+        (activity as? MainActivity)?.bottomNavigationView?.setVisible(false)
         (activity as? MainActivity)?.appBarLayout?.setExpanded(false, false)
         appBarLayoutSecurity?.setExpanded(true, true)
     }
@@ -79,7 +79,7 @@ class SecurityDetailFragment : Fragment() {
     }
 
     private fun restoreActivityState() {
-        (activity as? MainActivity)?.bottomNavigationView?.toggle(true)
+        (activity as? MainActivity)?.bottomNavigationView?.setVisible(true)
         appBarLayoutSecurity?.setExpanded(false, false)
         (activity as? MainActivity)?.appBarLayout?.setExpanded(true, false)
     }

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/splash/SplashFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/splash/SplashFragment.kt
@@ -11,13 +11,10 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import androidx.navigation.fragment.findNavController
 import ca.etsmtl.applets.etsmobile.R
-import ca.etsmtl.applets.etsmobile.presentation.login.LoginViewModel
-import ca.etsmtl.applets.etsmobile.presentation.main.MainActivity
-import ca.etsmtl.applets.etsmobile.util.EventObserver
 import ca.etsmtl.applets.etsmobile.extension.toast
-import ca.etsmtl.applets.etsmobile.extension.toggle
+import ca.etsmtl.applets.etsmobile.presentation.login.LoginViewModel
+import ca.etsmtl.applets.etsmobile.util.EventObserver
 import dagger.android.support.DaggerFragment
-import kotlinx.android.synthetic.main.activity_main.bottomNavigationView
 import kotlinx.android.synthetic.main.fragment_splash.progressBarSplash
 import javax.inject.Inject
 
@@ -41,8 +38,6 @@ class SplashFragment : DaggerFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        (activity as MainActivity).bottomNavigationView.toggle(false, 0)
 
         subscribeUI()
     }

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -62,6 +62,8 @@
         android:layout_gravity="bottom"
         android:layout_marginStart="0dp"
         android:layout_marginEnd="0dp"
+        android:visibility="invisible"
         app:labelVisibilityMode="labeled"
-        app:menu="@menu/navigation" />
+        app:menu="@menu/navigation"
+        tools:visibility="visible" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/android/app/src/main/res/values-en/strings.xml
+++ b/android/app/src/main/res/values-en/strings.xml
@@ -10,6 +10,7 @@
     <string name="session_winter">Winter</string>
     <string name="session_summer">Summer</string>
     <string name="session_without">Without Session</string>
+    <string name="oss_license_title">Open source licenses</string>
     <string name="facebook">Facebook</string>
     <string name="github">GitHub</string>
     <string name="email">Email</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="session_winter">Hiver</string>
     <string name="session_summer">Été</string>
     <string name="session_without">Sans trimestre</string>
-    <string name="oss_license_title" tools:ignore="MissingTranslation">Licences des logiciels libres</string>
+    <string name="oss_license_title">Licences des logiciels libres</string>
     <string name="facebook">Facebook</string>
     <string name="github">GitHub</string>
     <string name="email">Courriel</string>


### PR DESCRIPTION
Hide bottom navigation view to prevent user from bypassing the login screen. At launch, during a very small time frame, even though the BottomNavigationView hasn't appear on screen yet, the user was able to press on one of the items.