### PR TITLE
Small fixes

### DIFF
--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/main/MainActivity.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/main/MainActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.NavigationUI
+import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 import ca.etsmtl.applets.etsmobile.R
 import ca.etsmtl.applets.etsmobile.extension.getColorCompat
@@ -74,8 +75,8 @@ class MainActivity : BaseActivity() {
         val navController = findNavController(R.id.fragmentNavHostMain)
         val appBarConfiguration = AppBarConfiguration(topLevelDestinations)
 
-        toolbar.setupWithNavController(navController, appBarConfiguration)
         setSupportActionBar(toolbar)
+        setupActionBarWithNavController(navController, appBarConfiguration)
     }
 
     override fun onBackPressed() {
@@ -93,5 +94,11 @@ class MainActivity : BaseActivity() {
                 super.onBackPressed()
             }
         }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressed()
+
+        return true
     }
 }

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/main/MainActivity.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/main/MainActivity.kt
@@ -84,7 +84,9 @@ class MainActivity : BaseActivity() {
 
         if (currentId != R.id.fragmentLogin) {
             if (topLevelDestinations.contains(currentId)) {
-                if (currentId != R.id.fragmentDashboard) {
+                if (currentId == R.id.fragmentDashboard) {
+                    finishAffinity()
+                } else {
                     navController.navigate(R.id.fragmentDashboard)
                 }
             } else {

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/main/MainActivity.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/main/MainActivity.kt
@@ -47,7 +47,9 @@ class MainActivity : BaseActivity() {
 
         bottomNavigationView.setupWithNavController(navController)
         bottomNavigationView.setOnNavigationItemSelectedListener { item ->
-            if (!item.isChecked) {
+            val currentId = navController.currentDestination?.id
+
+            if (!item.isChecked && currentId != R.id.fragmentSplash && currentId != R.id.fragmentLogin) {
                 NavigationUI.onNavDestinationSelected(item, navController).apply {
                     if (this) {
                         appBarLayout.setExpanded(true, true)

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/main/MainActivity.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/main/MainActivity.kt
@@ -7,8 +7,8 @@ import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.NavigationUI
 import androidx.navigation.ui.setupWithNavController
 import ca.etsmtl.applets.etsmobile.R
-import ca.etsmtl.applets.etsmobile.presentation.BaseActivity
 import ca.etsmtl.applets.etsmobile.extension.getColorCompat
+import ca.etsmtl.applets.etsmobile.presentation.BaseActivity
 import kotlinx.android.synthetic.main.activity_main.appBarLayout
 import kotlinx.android.synthetic.main.activity_main.bottomNavigationView
 import kotlinx.android.synthetic.main.activity_main.toolbar
@@ -37,7 +37,7 @@ class MainActivity : BaseActivity() {
 
         setContentView(R.layout.activity_main)
 
-        setSupportActionBar(toolbar)
+        setupActionBar()
 
         setupBottomNavigation()
     }
@@ -58,9 +58,6 @@ class MainActivity : BaseActivity() {
             }
         }
 
-        val appBarConfiguration = AppBarConfiguration(topLevelDestinations)
-        toolbar.setupWithNavController(navController, appBarConfiguration)
-
         navController.addOnDestinationChangedListener { _, destination, _ ->
             if (!topLevelDestinations.contains(destination.id)) {
                 toolbar.navigationIcon?.setColorFilter(
@@ -69,6 +66,14 @@ class MainActivity : BaseActivity() {
                 )
             }
         }
+    }
+
+    private fun setupActionBar() {
+        val navController = findNavController(R.id.fragmentNavHostMain)
+        val appBarConfiguration = AppBarConfiguration(topLevelDestinations)
+
+        toolbar.setupWithNavController(navController, appBarConfiguration)
+        setSupportActionBar(toolbar)
     }
 
     override fun onBackPressed() {

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/security/SecurityDetailFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/security/SecurityDetailFragment.kt
@@ -12,9 +12,11 @@ import androidx.navigation.fragment.navArgs
 import androidx.navigation.ui.setupWithNavController
 import ca.etsmtl.applets.etsmobile.R
 import ca.etsmtl.applets.etsmobile.presentation.main.MainActivity
-import ca.etsmtl.applets.etsmobile.extension.setVisible
-import kotlinx.android.synthetic.main.activity_main.*
-import kotlinx.android.synthetic.main.fragment_security_detail.*
+import kotlinx.android.synthetic.main.activity_main.appBarLayout
+import kotlinx.android.synthetic.main.fragment_security_detail.appBarLayoutSecurity
+import kotlinx.android.synthetic.main.fragment_security_detail.btnEmergencyCall
+import kotlinx.android.synthetic.main.fragment_security_detail.toolbarSecurity
+import kotlinx.android.synthetic.main.fragment_security_detail.webView
 
 class SecurityDetailFragment : Fragment() {
     private val args: SecurityDetailFragmentArgs by navArgs()
@@ -24,38 +26,30 @@ class SecurityDetailFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
+        (activity as? MainActivity)?.appBarLayout?.setExpanded(false, false)
+
         // Inflate the layout for this fragment
         return inflater.inflate(R.layout.fragment_security_detail, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        setInitialActivityState()
-        setUpToolbarSecurityDetail()
+
+        setupToolbarSecurityDetail()
         setEmergencyDetailText()
         setButtonListener()
     }
 
     private fun setEmergencyDetailText() {
-        val securityTypeList = resources.getStringArray(R.array.security_type)
-        webView.loadUrl(
-            when (args.securityTitle) {
-                securityTypeList[0] -> resources.getString(R.string.bomb_threat)
-                securityTypeList[1] -> resources.getString(R.string.suspicious_packages)
-                securityTypeList[2] -> resources.getString(R.string.evacuation)
-                securityTypeList[3] -> resources.getString(R.string.gas_leak)
-                securityTypeList[4] -> resources.getString(R.string.fire)
-                securityTypeList[5] -> resources.getString(R.string.broken_elevator)
-                securityTypeList[6] -> resources.getString(R.string.electrical_outage)
-                securityTypeList[7] -> resources.getString(R.string.armed_person)
-                securityTypeList[8] -> resources.getString(R.string.earthquake)
-                else -> resources.getString(R.string.medical_emergency)
-            }
-        )
+        val securityTypeList = resources.getStringArray(R.array.array_security_type)
+        val fileUrlIndex = securityTypeList.indexOf(args.securityTitle)
+        val fileUrl = resources.getStringArray(R.array.array_security_file)[fileUrlIndex]
+
+        webView.loadUrl(fileUrl)
     }
 
     private fun setButtonListener() {
-        urgence_appel_urgence.setOnClickListener {
+        btnEmergencyCall.setOnClickListener {
             val uri = "tel:" + resources.getString(R.string.emergency_number)
             val intent = Intent(Intent.ACTION_DIAL)
             intent.data = Uri.parse(uri)
@@ -63,24 +57,14 @@ class SecurityDetailFragment : Fragment() {
         }
     }
 
-    private fun setInitialActivityState() {
-        (activity as? MainActivity)?.bottomNavigationView?.setVisible(false)
-        (activity as? MainActivity)?.appBarLayout?.setExpanded(false, false)
+    private fun setupToolbarSecurityDetail() {
+        toolbarSecurity.setupWithNavController(findNavController())
         appBarLayoutSecurity?.setExpanded(true, true)
     }
 
-    private fun setUpToolbarSecurityDetail() {
-        toolbarSecurity.setupWithNavController(findNavController())
-    }
-
     override fun onDestroyView() {
-        restoreActivityState()
-        super.onDestroyView()
-    }
-
-    private fun restoreActivityState() {
-        (activity as? MainActivity)?.bottomNavigationView?.setVisible(true)
-        appBarLayoutSecurity?.setExpanded(false, false)
         (activity as? MainActivity)?.appBarLayout?.setExpanded(true, false)
+
+        super.onDestroyView()
     }
 }

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/security/SecurityFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/security/SecurityFragment.kt
@@ -145,7 +145,6 @@ class SecurityFragment : Fragment(), OnMapReadyCallback {
         appBarLayout?.setExpanded(true, true)
     }
 
-
     private fun restoreActivityState() {
         (activity as? MainActivity)?.apply {
             bottomNavigationView?.setVisible(true)

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/security/SecurityFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/security/SecurityFragment.kt
@@ -10,12 +10,18 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import ca.etsmtl.applets.etsmobile.R
+import ca.etsmtl.applets.etsmobile.extension.setVisible
+import ca.etsmtl.applets.etsmobile.presentation.main.MainActivity
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.MarkerOptions
-import kotlinx.android.synthetic.main.fragment_security.*
+import kotlinx.android.synthetic.main.activity_main.appBarLayout
+import kotlinx.android.synthetic.main.activity_main.bottomNavigationView
+import kotlinx.android.synthetic.main.fragment_security.mapView
+import kotlinx.android.synthetic.main.fragment_security.rvSecurity
+import kotlinx.android.synthetic.main.fragment_security.viewCallEmergency
 
 /**
  * This fragment contains information about the security.
@@ -31,6 +37,8 @@ class SecurityFragment : Fragment(), OnMapReadyCallback {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        setInitialActivityState()
         setMap(savedInstanceState)
         setRecyclerView()
         setViewListener()
@@ -42,7 +50,7 @@ class SecurityFragment : Fragment(), OnMapReadyCallback {
     }
 
     private fun setViewListener() {
-        viewCall.setOnClickListener {
+        viewCallEmergency.setOnClickListener {
             val uri = "tel:" + resources.getString(R.string.emergency_number)
             val intent = Intent(Intent.ACTION_DIAL)
             intent.data = Uri.parse(uri)
@@ -51,8 +59,8 @@ class SecurityFragment : Fragment(), OnMapReadyCallback {
     }
 
     private fun setRecyclerView() {
-        val itemsList = resources.getStringArray(R.array.security_type)
-        security_recycler_view.apply {
+        val itemsList = resources.getStringArray(R.array.array_security_type)
+        rvSecurity.apply {
             setHasFixedSize(true)
             layoutManager = LinearLayoutManager(context)
             adapter = SecurityAdapter(itemsList, findNavController())
@@ -121,6 +129,8 @@ class SecurityFragment : Fragment(), OnMapReadyCallback {
     }
 
     override fun onDestroy() {
+        restoreActivityState()
+
         mapView?.onDestroy()
         super.onDestroy()
     }
@@ -128,5 +138,18 @@ class SecurityFragment : Fragment(), OnMapReadyCallback {
     override fun onLowMemory() {
         super.onLowMemory()
         mapView.onLowMemory()
+    }
+
+    private fun setInitialActivityState() = (activity as? MainActivity)?.apply {
+        bottomNavigationView?.setVisible(false)
+        appBarLayout?.setExpanded(true, true)
+    }
+
+
+    private fun restoreActivityState() {
+        (activity as? MainActivity)?.apply {
+            bottomNavigationView?.setVisible(true)
+            appBarLayout?.setExpanded(true, true)
+        }
     }
 }

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -62,7 +62,6 @@
         android:layout_gravity="bottom"
         android:layout_marginStart="0dp"
         android:layout_marginEnd="0dp"
-        android:visibility="invisible"
         app:labelVisibilityMode="labeled"
         app:menu="@menu/navigation"
         tools:visibility="visible" />

--- a/android/app/src/main/res/layout/fragment_security.xml
+++ b/android/app/src/main/res/layout/fragment_security.xml
@@ -6,9 +6,7 @@
     android:id="@+id/nestedScrollView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginBottom="@dimen/material_layout_vertical_spacing_tool_bar"
     tools:context="ca.etsmtl.applets.etsmobile.presentation.security.SecurityFragment">
-
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -23,7 +21,7 @@
             tools:layout_editor_absoluteX="0dp" />
 
         <TextView
-            android:id="@+id/txtReachSecurity"
+            android:id="@+id/tvReachSecurity"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:padding="16dp"
@@ -33,65 +31,70 @@
             app:layout_constraintTop_toBottomOf="@+id/mapView"
             tools:layout_editor_absoluteX="0dp" />
 
+        <View
+            android:id="@+id/viewCallEmergency"
+            android:layout_width="0dp"
+            android:layout_height="72dp"
+            android:background="?android:attr/selectableItemBackground"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tvReachSecurity" />
+
         <ImageView
-            android:id="@+id/imagePhone1"
+            android:id="@+id/ivPhoneEmergency"
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
             android:src="@drawable/ic_phone_black_24dp"
+            app:layout_constraintBottom_toBottomOf="@+id/viewCallEmergency"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/txtReachSecurity" />
+            app:layout_constraintTop_toBottomOf="@+id/tvReachSecurity" />
 
         <TextView
-            android:id="@+id/textEmergencyCall"
+            android:id="@+id/tvEmergencyCall"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="32dp"
             android:text="@string/emergency_call"
             android:textAppearance="?android:attr/textAppearanceLarge"
             android:textSize="17sp"
-            app:layout_constraintStart_toEndOf="@+id/imagePhone1"
-            app:layout_constraintTop_toTopOf="@+id/imagePhone1" />
+            app:layout_constraintBottom_toTopOf="@+id/tvEmergencyNumber"
+            app:layout_constraintStart_toEndOf="@+id/ivPhoneEmergency"
+            app:layout_constraintTop_toBottomOf="@+id/tvReachSecurity"
+            app:layout_constraintVertical_chainStyle="packed" />
 
         <TextView
-            android:id="@+id/textEmergencyNumber"
+            android:id="@+id/tvEmergencyNumber"
             android:layout_width="wrap_content"
             android:layout_height="15dp"
             android:text="@string/emergency_number"
             android:textSize="@dimen/material_component_lists_two_line_secondary_text_size"
-            app:layout_constraintStart_toStartOf="@+id/textEmergencyCall"
-            app:layout_constraintTop_toBottomOf="@+id/textEmergencyCall" />
-
-        <View
-            android:id="@+id/viewCall"
-            android:layout_width="209dp"
-            android:layout_height="40dp"
-            app:layout_constraintEnd_toEndOf="@+id/textEmergencyCall"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="@+id/imagePhone1"
-            app:layout_constraintTop_toTopOf="@+id/imagePhone1" />
+            app:layout_constraintBottom_toBottomOf="@+id/viewCallEmergency"
+            app:layout_constraintStart_toStartOf="@+id/tvEmergencyCall"
+            app:layout_constraintTop_toBottomOf="@+id/tvEmergencyCall" />
 
         <ImageView
-            android:id="@+id/imagePhone2"
+            android:id="@+id/ivPhoneInternal"
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:layout_marginStart="16dp"
-            android:layout_marginTop="36dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
             android:src="@drawable/ic_phone_black_24dp"
+            app:layout_constraintBottom_toTopOf="@+id/txtEmergencyProcedures"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/imagePhone1" />
+            app:layout_constraintTop_toBottomOf="@+id/viewCallEmergency" />
 
         <TextView
-            android:id="@+id/textEmergencyInternCall"
+            android:id="@+id/tvEmergencyInternCall"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="32dp"
+            android:layout_marginTop="8dp"
             android:text="@string/emergency_intern_call"
             android:textAppearance="?android:attr/textAppearanceLarge"
             android:textSize="17sp"
-            app:layout_constraintStart_toEndOf="@+id/imagePhone2"
-            app:layout_constraintTop_toTopOf="@+id/imagePhone2" />
+            app:layout_constraintStart_toStartOf="@+id/tvEmergencyCall"
+            app:layout_constraintTop_toBottomOf="@+id/viewCallEmergency" />
 
         <TextView
             android:id="@+id/textEmergencyInternNumber"
@@ -99,8 +102,8 @@
             android:layout_height="wrap_content"
             android:text="@string/emergency_intern_number"
             android:textSize="@dimen/material_component_lists_two_line_secondary_text_size"
-            app:layout_constraintStart_toStartOf="@+id/textEmergencyInternCall"
-            app:layout_constraintTop_toBottomOf="@+id/textEmergencyInternCall" />
+            app:layout_constraintStart_toStartOf="@+id/tvEmergencyInternCall"
+            app:layout_constraintTop_toBottomOf="@+id/tvEmergencyInternCall" />
 
         <TextView
             android:id="@+id/txtEmergencyProcedures"
@@ -111,21 +114,17 @@
             android:text="@string/emergency_procedures"
             android:textAppearance="?android:attr/textAppearanceLarge"
             android:textColor="@color/material_red_500"
-            app:layout_constraintTop_toBottomOf="@+id/textEmergencyInternNumber"
-            tools:layout_editor_absoluteX="0dp" />
+            app:layout_constraintTop_toBottomOf="@+id/textEmergencyInternNumber" />
 
         <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/security_recycler_view"
+            android:id="@+id/rvSecurity"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:nestedScrollingEnabled="false"
             android:scrollbars="none"
             app:layout_constraintTop_toBottomOf="@+id/txtEmergencyProcedures"
-            tools:layout_editor_absoluteX="4dp" />
-
+            tools:listitem="@layout/item_security" />
     </androidx.constraintlayout.widget.ConstraintLayout>
-
-
 </androidx.core.widget.NestedScrollView>
 
 

--- a/android/app/src/main/res/layout/fragment_security_detail.xml
+++ b/android/app/src/main/res/layout/fragment_security_detail.xml
@@ -3,10 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/coordinatorLayoutSecurity"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:theme="@style/AppTheme.Toolbar"
-    tools:context="ca.etsmtl.applets.etsmobile.presentation.main.MainActivity">
+    android:layout_height="match_parent">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appBarLayoutSecurity"
@@ -29,31 +26,30 @@
                 android:id="@+id/toolbarSecurity"
                 android:layout_width="match_parent"
                 android:layout_height="?android:attr/actionBarSize"
+                android:theme="@style/AppTheme.Toolbar"
                 app:titleTextColor="@android:color/white"
                 tools:title="Title" />
         </com.google.android.material.appbar.CollapsingToolbarLayout>
-
-
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/material_light_white"
+        android:background="@android:color/white"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <WebView
             android:id="@+id/webView"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
-
     </androidx.core.widget.NestedScrollView>
 
     <com.google.android.material.button.MaterialButton
-        android:id="@+id/urgence_appel_urgence"
+        android:id="@+id/btnEmergencyCall"
+        style="@style/Widget.MaterialComponents.Button.Icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|center"
-        android:text="@string/emergency_call" />
-
+        android:text="@string/emergency_call"
+        app:icon="@drawable/ic_phone_black_24dp" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/android/app/src/main/res/layout/item_security.xml
+++ b/android/app/src/main/res/layout/item_security.xml
@@ -2,7 +2,8 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="48dp">
+    android:layout_height="48dp"
+    android:background="?android:attr/selectableItemBackground">
 
     <TextView
         android:id="@+id/titleTypeUrgence"
@@ -20,9 +21,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentEnd="true"
-        android:layout_marginEnd="16dp"
         android:layout_centerVertical="true"
+        android:layout_marginEnd="16dp"
         android:src="@drawable/ic_keyboard_arrow_right_black_24dp" />
-
-
 </RelativeLayout>

--- a/android/app/src/main/res/navigation/nav_graph_main.xml
+++ b/android/app/src/main/res/navigation/nav_graph_main.xml
@@ -63,6 +63,14 @@
             app:destination="@id/securityDetailFragment" />
     </fragment>
     <fragment
+        android:id="@+id/securityDetailFragment"
+        android:name="ca.etsmtl.applets.etsmobile.presentation.security.SecurityDetailFragment"
+        android:label="{securityTitle}" >
+        <argument
+            android:name="securityTitle"
+            app:argType="string" />
+    </fragment>
+    <fragment
         android:id="@+id/fragmentMore"
         android:name="ca.etsmtl.applets.etsmobile.presentation.more.MoreFragment"
         android:label="@string/title_more"
@@ -82,12 +90,4 @@
         android:id="@+id/activityOpenSourceLicenses"
         android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity">
     </activity>
-    <fragment
-        android:id="@+id/securityDetailFragment"
-        android:name="ca.etsmtl.applets.etsmobile.presentation.security.SecurityDetailFragment"
-        android:label="{securityTitle}" >
-        <argument
-            android:name="securityTitle"
-            app:argType="string" />
-    </fragment>
 </navigation>

--- a/android/app/src/main/res/navigation/nav_graph_main.xml
+++ b/android/app/src/main/res/navigation/nav_graph_main.xml
@@ -47,23 +47,23 @@
         tools:layout="@layout/fragment_ets" >
         <action
             android:id="@+id/action_navigation_ets_to_securityFragment"
-            app:destination="@id/securityFragment"
+            app:destination="@id/fragmentSecurity"
             app:enterAnim="@anim/nav_default_enter_anim"
             app:exitAnim="@anim/nav_default_exit_anim"
             app:popEnterAnim="@anim/nav_default_pop_enter_anim"
             app:popExitAnim="@anim/nav_default_pop_exit_anim" />
     </fragment>
     <fragment
-        android:id="@+id/securityFragment"
+        android:id="@+id/fragmentSecurity"
         android:name="ca.etsmtl.applets.etsmobile.presentation.security.SecurityFragment"
         android:label="@string/title_security"
         tools:layout="@layout/fragment_security" >
         <action
             android:id="@+id/action_securityFragment_to_securityDetailFragment"
-            app:destination="@id/securityDetailFragment" />
+            app:destination="@id/fragmentSecurityDetail" />
     </fragment>
     <fragment
-        android:id="@+id/securityDetailFragment"
+        android:id="@+id/fragmentSecurityDetail"
         android:name="ca.etsmtl.applets.etsmobile.presentation.security.SecurityDetailFragment"
         android:label="{securityTitle}" >
         <argument

--- a/android/app/src/main/res/values-en/strings.xml
+++ b/android/app/src/main/res/values-en/strings.xml
@@ -131,7 +131,7 @@
     <string name="buglife_steps_to_reproduce">Steps to reproduce</string>
 
     <!-- Security -->
-    <string-array name="security_type">
+    <string-array name="array_security_type">
         <item>Bomb threat</item>
         <item>Suspicious packages</item>
         <item>Evacuation</item>
@@ -144,21 +144,24 @@
         <item>Medical emergency</item>
     </string-array>
 
-    <string name="bomb_threat">file:///android_asset/bomb_threat_detail_en.html</string>
-    <string name="suspicious_packages">file:///android_asset/suspicious_packages_detail_en.html</string>
-    <string name="evacuation">file:///android_asset/evacuation_detail_en.html</string>
-    <string name="gas_leak">file:///android_asset/gas_leak_detail_en.html</string>
-    <string name="fire">file:///android_asset/fire_detail_en.html</string>
-    <string name="broken_elevator">file:///android_asset/broken_elevator_detail_en.html</string>
-    <string name="electrical_outage">file:///android_asset/electrical_outage_detail_en.html</string>
-    <string name="armed_person">file:///android_asset/armed_person_detail_en.html</string>
-    <string name="earthquake">file:///android_asset/earthquake_detail_en.html</string>
-    <string name="medical_emergency">file:///android_asset/medical_emergency_detail_en.html</string>
+    <string-array name="array_security_file">
+        <item>file:///android_asset/bomb_threat_detail_en.html</item>
+        <item>file:///android_asset/suspicious_packages_detail_en.html</item>
+        <item>file:///android_asset/evacuation_detail_en.html</item>
+        <item>file:///android_asset/gas_leak_detail_en.html</item>
+        <item>file:///android_asset/fire_detail_en.html</item>
+        <item>file:///android_asset/broken_elevator_detail_en.html</item>
+        <item>file:///android_asset/electrical_outage_detail_en.html</item>
+        <item>file:///android_asset/armed_person_detail_en.html</item>
+        <item>file:///android_asset/earthquake_detail_en.html</item>
+        <item>file:///android_asset/medical_emergency_detail_en.html</item>
+    </string-array>
+
     <string name="emergency_call">Emergency call</string>
     <string name="reach_security">Reach security</string>
     <string name="emergency_number">514 396–8900</string>
     <string name="emergency_intern_call">From inside campus</string>
-    <string name="emergency_intern_number">55</string>
+    <string name="emergency_intern_number">Ex. 55</string>
     <string name="emergency_procedures">Emergency procedures</string>
     <string name="security_station">Security station</string>
     <string name="msg_no_seances_today">No class scheduled today</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -131,7 +131,7 @@
 
 
     <!-- Security -->
-    <string-array name="security_type">
+    <string-array name="array_security_type">
         <item>Appel à la bombe</item>
         <item>Colis suspect</item>
         <item>Évacuation</item>
@@ -144,21 +144,24 @@
         <item>Urgence médicale</item>
     </string-array>
 
-    <string name="bomb_threat">file:///android_asset/bomb_threat_detail_fr.html</string>
-    <string name="suspicious_packages">file:///android_asset/suspicious_packages_detail_fr.html</string>
-    <string name="evacuation">file:///android_asset/evacuation_detail_fr.html</string>
-    <string name="gas_leak">file:///android_asset/gas_leak_detail_fr.html</string>
-    <string name="fire">file:///android_asset/fire_detail_fr.html</string>
-    <string name="broken_elevator">file:///android_asset/broken_elevator_detail_fr.html</string>
-    <string name="electrical_outage">file:///android_asset/electrical_outage_detail_fr.html</string>
-    <string name="armed_person">file:///android_asset/armed_person_detail_fr.html</string>
-    <string name="earthquake">file:///android_asset/earthquake_detail_fr.html</string>
-    <string name="medical_emergency">file:///android_asset/medical_emergency_detail_fr.html</string>
+    <string-array name="array_security_file">
+        <item>file:///android_asset/bomb_threat_detail_fr.html</item>
+        <item>file:///android_asset/suspicious_packages_detail_fr.html</item>
+        <item>file:///android_asset/evacuation_detail_fr.html</item>
+        <item>file:///android_asset/gas_leak_detail_fr.html</item>
+        <item>file:///android_asset/fire_detail_fr.html</item>
+        <item>file:///android_asset/broken_elevator_detail_fr.html</item>
+        <item>file:///android_asset/electrical_outage_detail_fr.html</item>
+        <item>file:///android_asset/armed_person_detail_fr.html</item>
+        <item>file:///android_asset/earthquake_detail_fr.html</item>
+        <item>file:///android_asset/medical_emergency_detail_fr.html</item>
+    </string-array>
+
     <string name="emergency_call">Appel d\'urgence</string>
     <string name="reach_security">Joindre la sécurité</string>
     <string name="emergency_number">514 396–8900</string>
     <string name="emergency_intern_call">À l\'interne</string>
-    <string name="emergency_intern_number">55</string>
+    <string name="emergency_intern_number">Poste 55</string>
     <string name="emergency_procedures">Procédures d\'urgence</string>
     <string name="security_station">Poste de sécurité</string>
     <string name="msg_no_seances_today">Aucune séance de cours à l\'horaire aujourd\'hui</string>


### PR DESCRIPTION
- In `SecurityDetailFragment`, remove switch case (`when`) used to select the security HTML file. An index is now used instead.
- Fix naming problems (e.g. `security_recycler_view was` used instead of `rvSecurity`)
- Add `selectableItemBackground` to clickable items in `SecurityFragment`
- Center phone icons vertically in `SecurityFragment`
- Specify that `55` is an extension number
- Add phone icon to "Appel d'urgence" button in `SecurityDetailFragment`
- Fix title not restored when the Activity was recreated
- Fix `BottomNavigationView`'s visibility not restored when the Activity was recreated (caused by #51). Now, before triggering the navigation, we check that the current destination is not equal to the splash fragment or the login fragment.
