### PR TITLE
Disable grades card RecyclerView nested scroll

### DIFF
--- a/android/app/src/main/res/layout/fragment_grades_card.xml
+++ b/android/app/src/main/res/layout/fragment_grades_card.xml
@@ -32,6 +32,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:descendantFocusability="blocksDescendants"
+        android:nestedScrollingEnabled="false"
         android:paddingStart="6dp"
         android:paddingEnd="6dp"
         app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
The user could not scroll the dashboard from within the `RecyclerView`.