### PR TITLE
Add ProgressTimeLatch to SwipeRefreshLayout

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -1,6 +1,6 @@
 # Projet Notre-Dame
 
-[![Build Status](https://travis-ci.org/ApplETS/Notre-Dame.svg?branch=master)](https://travis-ci.org/ApplETS/Notre-Dame)
+[![Build Status](https://travis-ci.com/ApplETS/Notre-Dame.svg?branch=master)](https://travis-ci.org/ApplETS/Notre-Dame)
 
 Ce projet concrétise la troisième version de l'application mobile ÉTSMobile pour Android et iOS. Il s'agit de portail principal entre l'utilisateur et l'[École de technologie supérieure (ÉTS)](https://www.etsmtl.ca/) sur appareils mobiles. ÉTSMobile est un projet open-source développé par les membres du club étudiant [ApplETS](https://clubapplets.ca/). L'application offre notamment :
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Projet Notre-Dame
 
-[![Build Status](https://travis-ci.org/ApplETS/Notre-Dame.svg?branch=master)](https://travis-ci.org/ApplETS/Notre-Dame)
+[![Build Status](https://travis-ci.com/ApplETS/Notre-Dame.svg?branch=master)](https://travis-ci.org/ApplETS/Notre-Dame)
 
 This project is the placeholder for the third version of ÉTSMobile, a mobile which application that is currently available for Android and iOS. ÉTSMobile is the main gateway between the user and the [École de technologie supérieure (ÉTS)](https://www.etsmtl.ca/) on mobile devices. ÉTSMobile is an open-source project and is developped by members of the student club [ApplETS](https://clubapplets.ca/). It offers:
 

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/grades/GradesFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/grades/GradesFragment.kt
@@ -46,10 +46,10 @@ class GradesFragment : DaggerFragment() {
                 currentCourseShown = cours
                 this@GradesFragment.activity?.let {
                     GradesDetailsActivity.start(
-                            it as AppCompatActivity,
-                            holder.itemView,
-                            holder.tvCourseSigle,
-                            cours
+                        it as AppCompatActivity,
+                        holder.itemView,
+                        holder.tvCourseSigle,
+                        cours
                     )
                 }
             }
@@ -88,9 +88,10 @@ class GradesFragment : DaggerFragment() {
     }
 
     private fun subscribeUI() {
-        gradesViewModel.cours.observe(this, Observer {
-            it?.takeIf { it.isNotEmpty() }?.let { adapter.items = it }
-        })
+        gradesViewModel.cours
+            .observe(this, Observer {
+                it?.takeIf { it.isNotEmpty() }?.let { adapter.items = it }
+            })
 
         gradesViewModel.showEmptyView.observe(this, Observer {
             recyclerViewCoursesGrades.isVisible = it == false

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/grades/GradesFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/grades/GradesFragment.kt
@@ -16,6 +16,7 @@ import ca.etsmtl.applets.etsmobile.util.EventObserver
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexboxLayoutManager
 import com.google.android.flexbox.JustifyContent
+import com.shopify.livedataktx.debounce
 import dagger.android.support.DaggerFragment
 import jp.wasabeef.recyclerview.animators.FadeInDownAnimator
 import kotlinx.android.synthetic.main.empty_view_courses_grades.btnRetry
@@ -89,6 +90,7 @@ class GradesFragment : DaggerFragment() {
 
     private fun subscribeUI() {
         gradesViewModel.cours
+            .debounce(100)
             .observe(this, Observer {
                 it?.takeIf { it.isNotEmpty() }?.let { adapter.items = it }
             })

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/util/ProgressTimeLatch.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/util/ProgressTimeLatch.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ca.etsmtl.applets.etsmobile.util
+
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+
+/**
+ * A class which acts as a time latch for show progress bars UIs. It waits a minimum time to be
+ * dismissed before showing. Once visible, the progress bar will be visible for
+ * a minimum amount of time to avoid "flashes" in the UI when an event could take
+ * a largely variable time to complete (from none, to a user perceivable amount).
+ *
+ * Works with an view through the lambda API.
+ */
+class ProgressTimeLatch(
+    private val delayMs: Long = 750,
+    private val minShowTime: Long = 500,
+    private val viewRefreshingToggle: ((Boolean) -> Unit)
+) {
+    private val handler = Handler(Looper.getMainLooper())
+    private var showTime = 0L
+
+    private val delayedShow = Runnable(this::show)
+    private val delayedHide = Runnable(this::hideAndReset)
+
+    var refreshing = false
+        set(value) {
+            if (field != value) {
+                field = value
+                handler.removeCallbacks(delayedShow)
+                handler.removeCallbacks(delayedHide)
+
+                if (value) {
+                    handler.postDelayed(delayedShow, delayMs)
+                } else if (showTime >= 0) {
+                    // We're already showing, lets check if we need to delay the hide
+                    val showTime = SystemClock.uptimeMillis() - showTime
+                    if (showTime < minShowTime) {
+                        handler.postDelayed(delayedHide, minShowTime - showTime)
+                    } else {
+                        // We've been showing longer than the min, so hide and clean up
+                        hideAndReset()
+                    }
+                } else {
+                    // We're not currently show so just hide and clean up
+                    hideAndReset()
+                }
+            }
+        }
+
+    private fun show() {
+        viewRefreshingToggle(true)
+        showTime = SystemClock.uptimeMillis()
+    }
+
+    private fun hideAndReset() {
+        viewRefreshingToggle(false)
+        showTime = 0
+    }
+}

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/util/ProgressTimeLatch.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/util/ProgressTimeLatch.kt
@@ -29,7 +29,7 @@ import android.os.SystemClock
  * Works with an view through the lambda API.
  */
 class ProgressTimeLatch(
-    private val delayMs: Long = 750,
+    private val delayMs: Long = 300,
     private val minShowTime: Long = 500,
     private val viewRefreshingToggle: ((Boolean) -> Unit)
 ) {

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/view/SwipeRefreshLayoutWithProgressTimeLatch.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/view/SwipeRefreshLayoutWithProgressTimeLatch.kt
@@ -1,0 +1,25 @@
+package ca.etsmtl.applets.etsmobile.view
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import ca.etsmtl.applets.etsmobile.util.ProgressTimeLatch
+
+/**
+ * Created by Sonphil on 30-03-19.
+ */
+
+class SwipeRefreshLayoutWithProgressTimeLatch @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : SwipeRefreshLayout(context, attrs) {
+    private val swipeRefreshLatch: ProgressTimeLatch by lazy {
+        ProgressTimeLatch {
+            super.setRefreshing(it)
+        }
+    }
+
+    override fun setRefreshing(refreshing: Boolean) {
+        swipeRefreshLatch.refreshing = refreshing
+    }
+}

--- a/android/app/src/main/res/layout/fragment_grades.xml
+++ b/android/app/src/main/res/layout/fragment_grades.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ca.etsmtl.applets.etsmobile.view.SwipeRefreshLayoutWithProgressTimeLatch xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/swipeRefreshLayoutCoursesGrades"
     android:layout_width="match_parent"
@@ -23,4 +23,4 @@
             tools:ignore="PrivateResource"
             tools:listitem="@layout/item_grade_course" />
     </FrameLayout>
-</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+</ca.etsmtl.applets.etsmobile.view.SwipeRefreshLayoutWithProgressTimeLatch>

--- a/android/app/src/main/res/layout/fragment_profile.xml
+++ b/android/app/src/main/res/layout/fragment_profile.xml
@@ -1,4 +1,4 @@
-<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ca.etsmtl.applets.etsmobile.view.SwipeRefreshLayoutWithProgressTimeLatch xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/swipeRefreshLayoutProfile"
@@ -14,4 +14,4 @@
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         tools:ignore="PrivateResource"
         tools:listitem="@layout/item_profile" />
-</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+</ca.etsmtl.applets.etsmobile.view.SwipeRefreshLayoutWithProgressTimeLatch>

--- a/android/app/src/main/res/layout/fragment_schedule.xml
+++ b/android/app/src/main/res/layout/fragment_schedule.xml
@@ -7,7 +7,7 @@
     android:layout_marginBottom="@dimen/design_bottom_navigation_height"
     tools:ignore="PrivateResource">
 
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+    <ca.etsmtl.applets.etsmobile.view.SwipeRefreshLayoutWithProgressTimeLatch
         android:id="@+id/swipeRefreshLayoutSchedule"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -22,6 +22,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"/>
         </FrameLayout>
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+    </ca.etsmtl.applets.etsmobile.view.SwipeRefreshLayoutWithProgressTimeLatch>
 </FrameLayout>
 


### PR DESCRIPTION
Ajout de classe `SwipeRefreshLayoutWithProgressTimeLatch`. Il s'agit d'un [SwipeRefreshLayout](https://developer.android.com/reference/android/support/v4/widget/SwipeRefreshLayout) combiné à une instance de [ProgressTimeLatch](https://github.com/chrisbanes/tivi/blob/96e7cae7560ffd358b8c58c47267ed1024df53f6/app/src/main/java/me/banes/chris/tivi/ui/ProgressTimeLatch.kt). Cette dernière a été tirée du repo suivant : https://github.com/chrisbanes/tivi
Le fonctionnement est similaire à [ContentLoadingProgressBar](https://developer.android.com/reference/android/support/v4/widget/ContentLoadingProgressBar). En mode release, le temps de chargement peut être très court. Lorsque c'était le cas, la barre de progression (le petit cercle avec la ProgressBar à l'intérieur) clignotait. En effet, le cercle apparaissait et disparaissait très rapidement. Parfois, la ProgressBar à l'intérieur n'avait même pas le temps d'apparaître.