### PR TITLE
Optimize travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
       #- ./gradlew connectedAndroidTest -PdisablePreDex
     deploy:
       provider: script
-      script: echo "Publishing Beta APK file" && ls android/ && ./gradlew assembleRelease -PdisablePreDex
+      script: android/scripts/deploy_beta.sh
       on:
         branch: optimize_travis_fix
     before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       # Set permissions and execute the configuration scripts
       - android/scripts/before_install.sh
     install:
-      # Create and start the Android emulator
+      ## Create and start the Android emulator
       - echo no | avdmanager create avd --force -n test -k "system-images;android-21;default;x86_64"
       - emulator -avd test -no-accel -no-snapshot -no-audio -no-window &
       - android/scripts/android-wait-for-emulator

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,24 +26,24 @@ matrix:
       - android/scripts/before_install.sh
     install:
       # Create and start the Android emulator
-      #- echo no | avdmanager create avd --force -n test -k "system-images;android-21;default;x86_64"
-      #- emulator -avd test -no-accel -no-snapshot -no-audio -no-window &
-      #- android/scripts/android-wait-for-emulator
-      #- adb shell input keyevent 82 &
+      - echo no | avdmanager create avd --force -n test -k "system-images;android-21;default;x86_64"
+      - emulator -avd test -no-accel -no-snapshot -no-audio -no-window &
+      - android/scripts/android-wait-for-emulator
+      - adb shell input keyevent 82 &
     before_script:
       - pwd
       - chmod +x gradlew
     script:
       # Compile and test the application
-      #- ./gradlew assembleDebug -PdisablePreDex
-      #- ./gradlew ktlintCheck > /dev/null
-      #- ./gradlew test > /dev/null
-      #- ./gradlew connectedAndroidTest -PdisablePreDex
+      - ./gradlew assembleDebug -PdisablePreDex
+      - ./gradlew ktlintCheck > /dev/null
+      - ./gradlew test > /dev/null
+      - ./gradlew connectedAndroidTest -PdisablePreDex
     deploy:
       provider: script
       script: android/scripts/deploy_beta.sh
       on:
-        branch: optimize_travis_fix
+        branch: master
     before_cache:
       # Cleanup cached gradle versions for wrapper
       # List content in wrapper/dist sorted by modification time and remove entries starting by the second entry

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,23 +25,23 @@ matrix:
       # Set permissions and execute the configuration scripts
       - android/scripts/before_install.sh
     install:
-      ## Create and start the Android emulator
-      - echo no | avdmanager create avd --force -n test -k "system-images;android-21;default;x86_64"
-      - emulator -avd test -no-accel -no-snapshot -no-audio -no-window &
-      - android/scripts/android-wait-for-emulator
-      - adb shell input keyevent 82 &
+      # Create and start the Android emulator
+      #- echo no | avdmanager create avd --force -n test -k "system-images;android-21;default;x86_64"
+      #- emulator -avd test -no-accel -no-snapshot -no-audio -no-window &
+      #- android/scripts/android-wait-for-emulator
+      #- adb shell input keyevent 82 &
     before_script:
       - pwd
       - chmod +x gradlew
     script:
       # Compile and test the application
-      - ./gradlew assembleDebug -PdisablePreDex
-      - ./gradlew ktlintCheck > /dev/null
-      - ./gradlew test > /dev/null
-      - ./gradlew connectedAndroidTest -PdisablePreDex
+      #- ./gradlew assembleDebug -PdisablePreDex
+      #- ./gradlew ktlintCheck > /dev/null
+      #- ./gradlew test > /dev/null
+      #- ./gradlew connectedAndroidTest -PdisablePreDex
     deploy:
       provider: script
-      script: echo "Publishing Beta APK file" && ./gradlew assembleRelease -PdisablePreDex
+      script: echo "Publishing Beta APK file" && ls && ./gradlew assembleRelease -PdisablePreDex
       on:
         branch: optimize_travis_fix
     before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,9 @@ matrix:
       - ./gradlew connectedAndroidTest -PdisablePreDex
     deploy:
       provider: script
-      script: 
-        - cd android
-        - echo "Publishing Beta APK file"
-        - ./gradlew publishBetaReleaseApk
+      script: echo "Publishing Beta APK file" && ./gradlew assembleRelease -PdisablePreDex
       on:
-        branch: master
+        branch: optimize_travis_fix
     before_cache:
       # Cleanup cached gradle versions for wrapper
       # List content in wrapper/dist sorted by modification time and remove entries starting by the second entry

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
       #- ./gradlew connectedAndroidTest -PdisablePreDex
     deploy:
       provider: script
-      script: echo "Publishing Beta APK file" && ls && ./gradlew assembleRelease -PdisablePreDex
+      script: echo "Publishing Beta APK file" && ls android/ && ./gradlew assembleRelease -PdisablePreDex
       on:
         branch: optimize_travis_fix
     before_cache:

--- a/android/scripts/before_install.sh
+++ b/android/scripts/before_install.sh
@@ -19,15 +19,6 @@ export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
 sudo ldconfig
 pwd
 
-# Decrypt secrets for potential deployments
-cd ../android
-openssl version -v
-openssl aes-256-cbc -k "$ENCRYPTED_ANDROID_GOOGLE_SERVICES_PW" -in ./encrypted/google-services.json.encrypted -out ./app/google-services.json -d
-openssl aes-256-cbc -k "$ENCRYPTED_ANDROID_SECRETS_XML_PW" -in ./encrypted/secrets.xml.encrypted -out ./app/src/main/res/values/secrets.xml -d
-openssl aes-256-cbc -k "$ENCRYPTED_ETSMOBILE_KEYSTORE_PW" -in ./encrypted/etsm_upload_ks.jks.encrypted -out ./etsm_upload_ks.jks -d
-openssl aes-256-cbc -k "$ENCRYPTED_KEYSTORE_PROPERTIES_PW" -in ./encrypted/keystore.properties.encrypted -out ./keystore.properties -d
-openssl aes-256-cbc -k "$ENCRYPTED_SERVICE_ACCOUNT_CREDENTIALS_BETA_PW" -in ./encrypted/service_account_credentials_beta.json.encrypted -out ./service_account_credentials_beta.json -d
-
 # Install OpenJDK 8 for compiling the application
 if ! dpkg -s openjdk-8-jdk >/dev/null 2>&1; then sudo apt-get update; sudo apt-get install openjdk-8-jdk; fi
 

--- a/android/scripts/deploy_beta.sh
+++ b/android/scripts/deploy_beta.sh
@@ -15,4 +15,5 @@ cd ..
 
 # Publish the application to the Play Store
 echo "Publishing Beta APK file"
-./gradlew publishBetaReleaseApk
+#./gradlew publishBetaReleaseApk
+./gradlew assembleRelease

--- a/android/scripts/deploy_beta.sh
+++ b/android/scripts/deploy_beta.sh
@@ -15,5 +15,4 @@ cd ..
 
 # Publish the application to the Play Store
 echo "Publishing Beta APK file"
-#./gradlew publishBetaReleaseApk
-./gradlew assembleRelease
+./gradlew publishBetaReleaseApk

--- a/android/scripts/deploy_beta.sh
+++ b/android/scripts/deploy_beta.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Deployment script for ÉTSMobile on Android
+# Club App|ETS
+
+# Since Travis-CI deletes the modifications during the build, we need to decrypt the secrets another time
+cd android
+pwd
+openssl version -v
+openssl aes-256-cbc -k "$ENCRYPTED_ANDROID_GOOGLE_SERVICES_PW" -in ./encrypted/google-services.json.encrypted -out ./app/google-services.json -d
+openssl aes-256-cbc -k "$ENCRYPTED_ANDROID_SECRETS_XML_PW" -in ./encrypted/secrets.xml.encrypted -out ./app/src/main/res/values/secrets.xml -d
+openssl aes-256-cbc -k "$ENCRYPTED_ETSMOBILE_KEYSTORE_PW" -in ./encrypted/etsm_upload_ks.jks.encrypted -out ./etsm_upload_ks.jks -d
+openssl aes-256-cbc -k "$ENCRYPTED_KEYSTORE_PROPERTIES_PW" -in ./encrypted/keystore.properties.encrypted -out ./keystore.properties -d
+openssl aes-256-cbc -k "$ENCRYPTED_SERVICE_ACCOUNT_CREDENTIALS_BETA_PW" -in ./encrypted/service_account_credentials_beta.json.encrypted -out ./service_account_credentials_beta.json -d
+cd ..
+
+# Publish the application to the Play Store
+echo "Publishing Beta APK file"
+./gradlew publishBetaReleaseApk


### PR DESCRIPTION
Les changements incorporés par #94 ont omis le fait que Travis retire les changements effectués lors de la compilation de l'application. Cela inclut le fait que les secrets extraits ne sont plus disponibles et par conséquent, il est nécessaire de refaire le tout afin que le déploiement fonctionne comme il faut.