### PR TITLE
Prevent two app bars from showing up in security details after config change

### DIFF
--- a/android/app/src/main/res/layout/btn_emergency_call.xml
+++ b/android/app/src/main/res/layout/btn_emergency_call.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/btnEmergencyCall"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom|center"
+    android:layout_marginBottom="16dp"
+    android:backgroundTint="@color/colorPrimary"
+    android:text="@string/emergency_call"
+    android:textColor="@android:color/white"
+    app:icon="@drawable/ic_phone_black_24dp"
+    app:iconTint="@android:color/white"
+    app:rippleColor="@android:color/white" />

--- a/android/app/src/main/res/layout/fragment_security_detail.xml
+++ b/android/app/src/main/res/layout/fragment_security_detail.xml
@@ -1,59 +1,13 @@
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/coordinatorLayoutSecurity"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@android:color/white"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/appBarLayoutSecurity"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:animateLayoutChanges="true"
-        app:expanded="false"
-        tools:expanded="true">
-
-        <com.google.android.material.appbar.CollapsingToolbarLayout
-            android:id="@+id/collapsingToolbarLayoutSecurity"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:expandedTitleGravity="top"
-            app:layout_scrollFlags="scroll"
-            app:titleEnabled="false">
-
-            <androidx.appcompat.widget.Toolbar
-                android:id="@+id/toolbarSecurity"
-                android:layout_width="match_parent"
-                android:layout_height="?android:attr/actionBarSize"
-                android:theme="@style/AppTheme.Toolbar"
-                app:titleTextColor="@android:color/white"
-                tools:title="Title" />
-        </com.google.android.material.appbar.CollapsingToolbarLayout>
-    </com.google.android.material.appbar.AppBarLayout>
-
-    <androidx.core.widget.NestedScrollView
+    <WebView
+        android:id="@+id/webView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@android:color/white"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
-
-        <WebView
-            android:id="@+id/webView"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginBottom="16dp" />
-    </androidx.core.widget.NestedScrollView>
-
-    <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
-        android:id="@+id/btnEmergencyCall"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom|center"
-        android:layout_marginBottom="16dp"
-        android:backgroundTint="@color/colorPrimary"
-        android:text="@string/emergency_call"
-        android:textColor="@android:color/white"
-        app:icon="@drawable/ic_phone_black_24dp"
-        app:iconTint="@android:color/white"
-        app:rippleColor="@android:color/white" />
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+        android:layout_marginBottom="16dp" />
+</androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
After a configuration change, `MainActivity`'s `AppBarLayout` and `SecurityDetailFragment`'s `AppBarLayout` appears.

- Remove `SecurityDetailFragment`'s `AppBarLayout` and simply use `MainActivity`'s `AppBarLayout`
- Remove emergency call button from `SecurityDetailFragment` and programmatically add it to `MainActivity`'s `CoordinatorLayout`. The button is removed when the user leave the `SecurityDetailFragment`. We need to do this because the `MainActivity`'s app bar will push the `SecurityDetailFragment`'s and cause the button to be partially hidden.