### PR TITLE
Restore dark theme pref when the app is restored

### DIFF
--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/App.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/App.kt
@@ -1,7 +1,9 @@
 package ca.etsmtl.applets.etsmobile.presentation
 
+import android.content.SharedPreferences
 import ca.etsmtl.applets.etsmobile.R
 import ca.etsmtl.applets.etsmobile.di.DaggerAppComponent
+import ca.etsmtl.applets.etsmobile.extension.applyDarkThemePref
 import ca.etsmtl.applets.repository.di.RepositoryModule
 import com.buglife.sdk.Buglife
 import com.buglife.sdk.InvocationMethod
@@ -9,6 +11,7 @@ import com.buglife.sdk.PickerInputField
 import com.buglife.sdk.TextInputField
 import dagger.android.AndroidInjector
 import dagger.android.support.DaggerApplication
+import javax.inject.Inject
 
 /**
  * Created by Sonphil on 28-02-18.
@@ -16,10 +19,14 @@ import dagger.android.support.DaggerApplication
 
 class App : DaggerApplication() {
 
+    @Inject
+    lateinit var prefs: SharedPreferences
+
     override fun onCreate() {
         super.onCreate()
 
         setupBuglife()
+        loadDarkThemePref()
     }
 
     private fun setupBuglife() {
@@ -45,5 +52,17 @@ class App : DaggerApplication() {
                 .application(this)
                 .repositoryModule(RepositoryModule(this))
                 .build()
+    }
+
+    /**
+     * Load dark theme preference and apply it
+     */
+    private fun loadDarkThemePref() {
+        val prefValue = prefs.getString(
+                getString(R.string.key_dark_theme_pref),
+                getString(R.string.default_entry_value_dark_theme_pref)
+        )
+
+        applyDarkThemePref(prefValue)
     }
 }

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/main/MainActivity.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/main/MainActivity.kt
@@ -13,7 +13,6 @@ import androidx.navigation.ui.NavigationUI
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 import ca.etsmtl.applets.etsmobile.R
-import ca.etsmtl.applets.etsmobile.extension.applyDarkThemePref
 import ca.etsmtl.applets.etsmobile.extension.getColorCompat
 import ca.etsmtl.applets.etsmobile.extension.setVisible
 import ca.etsmtl.applets.etsmobile.presentation.BaseActivity
@@ -43,7 +42,6 @@ class MainActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        loadDarkThemePref()
         setTheme(R.style.AppTheme)
         setContentView(R.layout.activity_main)
         setupActionBar()
@@ -114,13 +112,6 @@ class MainActivity : BaseActivity() {
         onBackPressed()
 
         return true
-    }
-
-    /**
-     * Load dark theme preference and apply it
-     */
-    private fun loadDarkThemePref() {
-        applyDarkThemePref(mainViewModel.getDarkThemePreferenceValue())
     }
 
     private fun subscribeUI() {

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/main/MainViewModel.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/main/MainViewModel.kt
@@ -1,11 +1,8 @@
 package ca.etsmtl.applets.etsmobile.presentation.main
 
-import android.content.Context
-import android.content.SharedPreferences
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import ca.etsmtl.applets.etsmobile.R
 import ca.etsmtl.applets.etsmobile.util.Event
 import javax.inject.Inject
 
@@ -13,10 +10,7 @@ import javax.inject.Inject
  * Created by Sonphil on 11-05-19.
  */
 
-class MainViewModel @Inject constructor(
-    private val context: Context,
-    private val prefs: SharedPreferences
-) : ViewModel() {
+class MainViewModel @Inject constructor() : ViewModel() {
     val topLevelDestinations = setOf(
         Destination.DASHBOARD,
         Destination.SCHEDULE,
@@ -63,9 +57,4 @@ class MainViewModel @Inject constructor(
             }
         }
     }
-
-    fun getDarkThemePreferenceValue(): String? = prefs.getString(
-        context.getString(R.string.key_dark_theme_pref),
-        context.getString(R.string.default_entry_value_dark_theme_pref)
-    )
 }

--- a/android/app/src/test/kotlin/ca/etsmtl/applets/etsmobile/presentation/MainViewModelTest.kt
+++ b/android/app/src/test/kotlin/ca/etsmtl/applets/etsmobile/presentation/MainViewModelTest.kt
@@ -1,7 +1,5 @@
 package ca.etsmtl.applets.etsmobile.presentation
 
-import android.content.Context
-import android.content.SharedPreferences
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
 import ca.etsmtl.applets.etsmobile.presentation.main.Destination
@@ -17,7 +15,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.Captor
-import org.mockito.Mockito.mock
 import org.mockito.MockitoAnnotations
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -31,9 +28,7 @@ class MainViewModelTest {
     @get:Rule
     val instantExecutorRule = InstantTaskExecutorRule()
 
-    private val context: Context = mock()
-    private val prefs: SharedPreferences = mock(SharedPreferences::class.java)
-    private val mainViewModel = MainViewModel(context, prefs)
+    private val mainViewModel = MainViewModel()
     private val closeAppObserver: Observer<Event<Unit>> = mock()
     private val navigateToDestinationObserver: Observer<Event<Destination>> = mock()
     private val navigateBackObserver: Observer<Event<Unit>> = mock()


### PR DESCRIPTION
When the user left the app in the background, the system could kill the app. When the user went back to the app, it would have to be recreated. However, the dark theme pref wasn't restored in some activities.