### PR TITLE
Try to fix class average too high (#145)

### DIFF
--- a/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/api/response/mapper/SignetsApiMapperExt.kt
+++ b/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/api/response/mapper/SignetsApiMapperExt.kt
@@ -89,7 +89,7 @@ fun ApiEtudiant.toEtudiantEntity() = EtudiantEntity(
 )
 
 fun ApiEvaluation.toEvaluationEntity(cours: Cours): EvaluationEntity {
-    val note = this.note.replaceCommaAndParseToDouble()
+    val note = this.note?.replaceCommaAndParseToDouble()
     val moyenne = this.moyenne.replaceCommaAndParseToDouble()
     var notePourcentage: Double? = null
     var moyennePourcentage: Double? = null
@@ -130,7 +130,7 @@ fun ApiListeDesElementsEvaluation.toEvaluationEntities(cours: Cours) = liste.map
 
 fun ApiListeDesElementsEvaluation.toSommaireEvaluationEntity(cours: Cours): SommaireElementsEvaluationEntity {
     val noteSur = liste.asSequence()
-            .filter { it.note.isNotBlank() && it.ignoreDuCalcul == "Non" }
+            .filter { it.note != null && it.ignoreDuCalcul == "Non" }
             .map { it.ponderation.replaceCommaAndParseToFloat() ?: 0f }
             .sum()
             .coerceAtMost(100f)

--- a/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/api/response/signets/ApiEvaluation.kt
+++ b/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/data/api/response/signets/ApiEvaluation.kt
@@ -9,7 +9,7 @@ data class ApiEvaluation(
     @Json(name = "nom") var nom: String,
     @Json(name = "equipe") var equipe: String,
     @Json(name = "dateCible") var dateCible: String,
-    @Json(name = "note") var note: String,
+    @Json(name = "note") var note: String?,
     /**
      * This string represents the value the exam is corrected on. The value can also contains the
      * bonus points separated by a plus sign  e.g. "50+3".


### PR DESCRIPTION
So far, the class of the user did two tests (MTest01 and MTest02), but the user got a "blank" grade for the first test. However, when the app calculates noteSur, it will filter blank grades. We now only filter null grades instead or null and blank grades like V2.

V2 : 
``` java
		for ( ElementEvaluation evaluationElement : courseEvaluation.liste) {
			if(evaluationElement.note !=null){
				if(evaluationElement.ignoreDuCalcul.equals("Non")){
					try {
						final String pond = evaluationElement.ponderation;
						final double value = nf_frCA.parse(pond).doubleValue();
						total += value;
						if(total>100){
							total = 100;
						}
					} catch (final ParseException e) {
					}
				}
			}
		}
```
V3 (after change) : 
``` kotlin
    val noteSur = liste.asSequence()
            .filter { it.note != null && it.ignoreDuCalcul == "Non" }
            .map { it.ponderation.replaceCommaAndParseToFloat() ?: 0f }
            .sum()
            .coerceAtMost(100f)
```