### PR TITLE
Dashboard cards suspend function

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -147,13 +147,13 @@ dependencies {
     testImplementation "org.mockito:mockito-inline:$versions.mockito"
 
     // Android Test Core library
-    androidTestImplementation 'androidx.test:core:1.1.0'
+    androidTestImplementation "androidx.test:core:$versions.test"
 
     // AndroidJUnitRunner and JUnit Rules
-    androidTestImplementation 'androidx.test:rules:1.1.1'
+    androidTestImplementation "androidx.test:rules:$versions.test"
 
     // Assertions
-    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
 
     // Espresso UI Testing
     androidTestImplementation "androidx.test.espresso:espresso-core:$versions.espresso"

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
             "dimens": "1.4",
             "espresso": "3.1.2-alpha01",
             "firebase": "16.0.9",
-            "firebase_crashlytics": "2.10.0",
+            "firebase_crashlytics": "2.10.1",
             "flexbox" : "1.1.0",
             "glide": "4.9.0",
             "google_maps": "16.1.0",
@@ -22,7 +22,7 @@ buildscript {
             "leakcanary": "2.0-alpha-1",
             "lifecycle": "2.0.0",
             "lifecycle_viewmodel_ktx": "2.2.0-alpha01",
-            "material_components": "1.1.0-alpha06",
+            "material_components": "1.1.0-alpha07",
             "materialprogressview": "1.0.6",
             "mockito": "2.23.4",
             "mockito_kotlin": "1.6.0",
@@ -32,7 +32,7 @@ buildscript {
             "recyclerviewanimators": "2.3.0",
             "retrofit": "2.5.0",
             "room": "2.1.0-alpha04",
-            "test": "1.1.2-alpha01",
+            "test": "1.2.0",
             "sqldelight": "1.0.3",
             "support": "1.0.0"
     ]

--- a/shared/src/commonMain/kotlin/domain/FetchDashboardCardsUseCase.kt
+++ b/shared/src/commonMain/kotlin/domain/FetchDashboardCardsUseCase.kt
@@ -10,5 +10,5 @@ import model.DashboardCard
  */
 
 class FetchDashboardCardsUseCase @Inject constructor(private val repository: DashboardCardRepository) {
-    operator fun invoke(): ReceiveChannel<List<DashboardCard>> = repository.dashboardCards()
+    suspend operator fun invoke(): ReceiveChannel<List<DashboardCard>> = repository.dashboardCards()
 }


### PR DESCRIPTION
- Update some dependencies
- Set dashboardCards methods as a suspend function in DashboardCardRepository
Return the channel directly instead of using the GlobalScope to produce a channel and consuming the first channel and offering the values to the second one.

The GlobalScope is normally used to launch top-level coroutines and does not scope the work properly. We now also declare FetchDashboardCardsUseCase's invoke operator as a suspend function. This function is called within the DashboardViewModel's scope. As a result, we now scope the work to the ViewModel, so that if the ViewModel is cleared, the work is canceled automatically.