### PR TITLE
Fix security call btn and remove chuck

### DIFF
--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/security/SecurityDetailFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/security/SecurityDetailFragment.kt
@@ -14,6 +14,7 @@ import ca.etsmtl.applets.etsmobile.presentation.main.MainActivity
 import kotlinx.android.synthetic.main.activity_main.appBarLayout
 import kotlinx.android.synthetic.main.activity_main.coordinatorLayout
 import kotlinx.android.synthetic.main.btn_emergency_call.btnEmergencyCall
+import kotlinx.android.synthetic.main.btn_emergency_call.view.btnEmergencyCall
 import kotlinx.android.synthetic.main.fragment_security_detail.webView
 
 class SecurityDetailFragment : Fragment() {
@@ -51,13 +52,17 @@ class SecurityDetailFragment : Fragment() {
         inflater: LayoutInflater
     ) {
         activity.coordinatorLayout?.let { coordinatorLayout ->
-            emergencyCallBtn = inflater.inflate(
-                R.layout.btn_emergency_call,
-                coordinatorLayout,
-                false
-            ) as Button
+            emergencyCallBtn = coordinatorLayout.btnEmergencyCall
 
-            coordinatorLayout.addView(emergencyCallBtn)
+            if (emergencyCallBtn == null) {
+                emergencyCallBtn = inflater.inflate(
+                    R.layout.btn_emergency_call,
+                    coordinatorLayout,
+                    false
+                ) as Button
+
+                coordinatorLayout.addView(emergencyCallBtn)
+            }
         }
     }
 

--- a/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/security/SecurityDetailFragment.kt
+++ b/android/app/src/main/kotlin/ca/etsmtl/applets/etsmobile/presentation/security/SecurityDetailFragment.kt
@@ -94,8 +94,9 @@ class SecurityDetailFragment : Fragment() {
         (activity as? MainActivity)?.let {
             it.appBarLayout?.setExpanded(true, true)
 
-            // Remove emergency call button from main layout
-            it.coordinatorLayout?.removeView(emergencyCallBtn)
+            // Remove emergency call button from MainActivity
+            emergencyCallBtn?.setOnClickListener(null)
+            (emergencyCallBtn?.parent as? ViewGroup)?.removeView(emergencyCallBtn)
         }
 
         super.onDestroyView()

--- a/android/repository/build.gradle
+++ b/android/repository/build.gradle
@@ -84,10 +84,6 @@ dependencies {
     // Mockito-Kotlin
     testImplementation "com.nhaarman:mockito-kotlin-kt1.1:$versions.mockito_kotlin"
 
-    // Chuck
-    debugImplementation "com.readystatesoftware.chuck:library:$versions.chuck"
-    releaseImplementation "com.readystatesoftware.chuck:library-no-op:$versions.chuck"
-
     // livedata-ktx
     api "com.shopify:livedata-ktx:2.0.1"
 

--- a/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/util/CustomTrust.kt
+++ b/android/repository/src/main/kotlin/ca/etsmtl/applets/repository/util/CustomTrust.kt
@@ -16,7 +16,6 @@
 package ca.etsmtl.applets.repository.util
 
 import android.content.Context
-import com.readystatesoftware.chuck.ChuckInterceptor
 import okhttp3.CertificatePinner
 import okhttp3.OkHttpClient
 import java.io.IOException
@@ -51,7 +50,6 @@ internal abstract class CustomTrust(context: Context) {
 
         OkHttpClient.Builder()
             .sslSocketFactory(sslSocketFactory, trustManager)
-            .addInterceptor(ChuckInterceptor(context.applicationContext))
             .build()
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ buildscript {
     ext.versions = [
             "android_ktx": "1.0.2",
             "buglife": "1.4.3",
-            "chuck": "1.1.0",
             "constraint_layout": "2.0.0-beta1",
             "coroutines": "1.1.1",
             "dagger": "2.22.1",


### PR DESCRIPTION
- Remove [Chuck](https://github.com/jgilfelt/chuck)
- Fix security button
When the user left `SecurityDetailsFragment` and went back, the security call button stopped working.